### PR TITLE
Vertical spatial domain check

### DIFF
--- a/code/tests/fixtures/test_cmr_metadata.echo10
+++ b/code/tests/fixtures/test_cmr_metadata.echo10
@@ -168,6 +168,9 @@ Lastly, users should continue to carefully observe and weigh information from th
                         </BoundingRectangle>
                   </Geometry>
             </HorizontalSpatialDomain>
+            <VerticalSpatialDomain>
+                  <Type>Maximum Deptha</Type>
+            </VerticalSpatialDomain>
             <GranuleSpatialRepresentation>GEODETIC</GranuleSpatialRepresentation>
       </Spatial>
       <AssociatedBrowseImageUrls>

--- a/schemas/check_messages.json
+++ b/schemas/check_messages.json
@@ -292,11 +292,19 @@
         "remediation": "Select a Granule Spatial Representation from this list: ['CARTESIAN', 'GEODETIC', 'ORBIT', ' NO_SPATIAL']."
     },
     "data_center_name_presence_check": {
-        "failure": "At least one DataCenter/ShortName must be provided per UMM requirements. ",
+        "failure": "At least one DataCenter/ShortName must be provided per UMM requirements.",
         "help": {
             "message": "",
             "url": ""
         },
         "remediation": "Please populate the ArchiveCenter field in order to meet the UMM requirement."
+    },
+    "vertical_spatial_domain_type_check": {
+        "failure": "The Vertical Spatial Domain Type `{}` does not align with the values used in the UMM-C schema.",
+        "help": {
+            "message": "",
+            "url": ""
+        },
+        "remediation": "Please provide a Vertical Spatial Domain Type from the following options to align with the UMM: ['Atmosphere Layer', 'Maximum Altitude', 'Maximum Depth', 'Minimum Altitude', 'Minimum Depth']"
     }
 }

--- a/schemas/checks.json
+++ b/schemas/checks.json
@@ -73,7 +73,10 @@
         "dependencies": [
             "datetime_format_check"
         ],
-        "data": ["now", "gte"],
+        "data": [
+            "now",
+            "gte"
+        ],
         "available": true
     },
     "doi_missing_reason_enumeration_check": {
@@ -365,6 +368,20 @@
     "doi_link_update": {
         "data_type": "url",
         "check_function": "doi_link_update",
+        "available": true
+    },
+    "vertical_spatial_domain_type_check": {
+        "data_type": "string",
+        "check_function": "controlled_keywords_check",
+        "data": [
+            [
+                "Atmosphere Layer",
+                "Maximum Altitude",
+                "Maximum Depth",
+                "Minimum Altitude",
+                "Minimum Depth"
+            ]
+        ],
         "available": true
     }
 }

--- a/schemas/rule_mapping.json
+++ b/schemas/rule_mapping.json
@@ -491,5 +491,16 @@
             }
         ],
         "severity": "info"
+    },
+    "vertical_spatial_domain_type_check": {
+        "rule_name": "Vertical Spatial Domain Type Check",
+        "fields_to_apply": [
+            {
+                "fields": [
+                    "Collection/Spatial/VerticalSpatialDomain/Type"
+                ]
+            }
+        ],
+        "severity": "error"
     }
 }


### PR DESCRIPTION
**Motivation**
The ECHO10 field 'Collection/Spatial/VerticalSpatialDomain/Type' is not controlled by the ECHO10 schema, but is controlled in the UMM schema. This checks against the UMM enumeration list for Vertical SPatial Domain Type for consistency.

**Changes**
The vertical spatial domain check has been added.

**Ramifications**
If the value for the field `Collection/Spatial/VerticalSpatialDomain/Type` is not in= in UMM-C VerticalSpatialDomainTypeEnum, i.e: `["Atmosphere Layer", "Maximum Altitude", "Maximum Depth", "Minimum Altitude", "Minimum Depth"]`, then an error message is shown in the output