### PR TITLE
Add documentation for checks

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -1,0 +1,217 @@
+# Adding a new check
+
+**Files that you need to work with:**
+
+1. `rules_override.json`
+2. `check_messages_override.json`
+
+**Steps:**
+
+1. Create a unique rule_id for your rule. Make it meaningful. Something like `doi_missing_reason_explanation` (no spaces).
+2. Make an entry to the json files with the same rule_id.
+3. In `rules_override.json`, add in the `fields_to_apply`, `data` and `check_id`. Add in the `echo10` and `dif10` fields corresponding to the rule. `check_id` should be one of the available `check_id`s (listed below). The format of `data` corresponding to each of these `check_id`s are given in the specifications below.
+
+## Available checks
+
+### Generic checks
+
+#### `date_compare`
+
+Compares the given two dates based on the relationship specified.
+Relationship supported: `lt`, `lte`, `gt`, `gte`, `eq` and `neq`.
+
+##### Case I: Compare two different datetime field values
+
+  Specify the two field in `fields` and the corresponding `relation`.
+
+##### Case II: Compare a field with a specific date
+
+  Specify the field in `fields`. Add the date and relation in `data` in the format `[{time}, {relation}]`. eg: `["now", "gte"]`
+  Currently only `now` is supported as a date
+
+#### `datetime_format_check`
+
+Checks whether the datetime is in the ISO format.
+
+#### `url_check`
+
+Checks if the url is correct, resolves to a webpage and gives a 200 OK status.
+
+#### `string_compare`
+
+Compares the two strings based on the relationship specified.
+Relationship supported: `lt`, `lte`, `gt`, `gte`, `eq` and `neq`.
+
+##### Case I: Compare two different string field values
+
+  Specify the two field in `fields` and the corresponding `relation`.
+
+##### Case II: Compare a field with a specific string
+
+  Specify the field in `fields`. Add the date and relation in `data` in the format `[{string}, {relation}]`. eg: `["FTP", "eq"]`
+
+#### `length_check`
+
+Checks if the legth of the field value adheres to the relationship specified.
+`data format`: `[{length}, {relation}]`. eg: `[100, "gte"]`.
+
+#### `availability_check`
+
+Checks the rule: if the first field is provided, the second field has to be provided.
+`fields: (ordered) [ {first_field}, {second_field} ]`
+
+#### `boolean_check`
+
+Checks if the field value is boolean, either `true` or `false` or any case combination of those.
+
+#### `controlled_keywords_check`
+
+Checks if the field value is one of the controlled keywords; provide the controlled keywords as `data` in the format:
+`[["keyword1", "keyword2",...]]`
+
+#### `doi_validity_check`
+
+Checks if the doi provided resolves to a valid document.
+
+#### `presence_check`
+
+Checks if one of the given fields is populated.
+
+### Miscellaneous Checks
+
+#### `bounding_coordinate_logic_check`
+
+Check that the North bounding coordinate is always larger than the South bounding coordinate and the East bounding coordinate is always larger than the West bounding coordinate.
+`fields`: the parent field 
+(eg. `Collection/Spatial/HorizontalSpatialDomain/Geometry/BoundingRectangle`)
+
+#### `characteristic_name_uniqueness_check`
+
+If multiple Charasteristics are provided, checks to see whether each of those names are unique.
+
+#### `collection_progress_consistency_check`
+
+There are a few fields pertaining to the status of the collection as either active or complete whose values should align with one another. This check looks across these related fields to make sure the values are logically consistent.
+
+For `ACTIVE` collections:
+`CollectionProgress = ACTIVE`
+No `EndingDateTime` should be provided
+`EndsAtPresentFlag` = `true`
+
+For `COMPLETE` collections:
+`CollectionProgress = COMPLETE`
+An `EndingDateTime` should be provided
+`EndsAtPresentFlag` = `false` OR no `EndsAtPresentFlag` provided 
+
+#### `doi_link_update`
+
+If `http://dx.doi.org` is provided, recommend updating it to `https://doi.org`
+
+#### `doi_missing_reason_explanation`
+
+If no DOI is provided, and the `DOI/MissingReason` field is populated, recommend adding an explanation for why there is no DOI.
+
+#### `ends_at_present_flag_logic_check`
+
+Checks the logic as follows:
+If `EndsAtPresentFlag` is populated:
+`true` -> check `EndingDateTime`, if there is no ending date time passes check; if there is an `EndingDateTime` display a warning
+`true` -> check `CollectionState/CollectionProgress`, if `CollectionState/CollectionProgress = ACTIVE` passes check; if `CollectionState/CollectionProgress = COMPLETE` display a warning
+`false` -> check `EndingDateTime`, if there is an ending date time passes check; if there is not an `EndingDateTime` display a warning
+`false` -> check `CollectionState/CollectionProgress`, if `CollectionState/CollectionProgress = COMPLETE` passes check; if `CollectionState/CollectionProgress = ACTIVE` display a warning
+
+#### `ends_at_present_flag_presence_check`
+
+If `EndsAtPresentFlag` is not populated:
+If no `EndingDateTime` is provided, print a warning that it might be necessary to add an `EndsAtPresentFlag` of `true`
+If an `EndingDateTime` is provided, passes check (no message needed)
+If `CollectionState` = `ACTIVE`, print a warning that it might be necessary to add an `EndsAtPresentFlag` of `true`
+If `CollectionState` = `COMPLETE`, passes check (no message needed)
+
+#### `get_data_url_check`
+
+Checks for `"GET DATA"` links (at least 1 should be provided). If no GET DATA links are provided this check will throw an error.
+
+#### `mime_type_check`
+
+Checks whether a `Mime Type` is provided for `'USE SERVICE API'` URLs (i.e. when the `URL Type` = `'USE SERVICE API'`).
+
+#### `opendap_url_location_check`
+
+Check to make sure that an OPeNDAP access URL is not provided in the `Online Access URL` field.
+
+#### `user_services_check`
+
+Check to make sure the fields aren't populated like this:
+
+```
+Collection/Contacts/Contact/ContactPersons/ContactPerson/FirstName: "User"
+Collection/Contacts/Contact/ContactPersons/ContactPerson/MiddleName: "null"
+Collection/Contacts/Contact/ContactPersons/ContactPerson/LastName: "Services"
+```
+
+#### `validate_beginning_datetime_against_granules`
+
+Checks whether the beginning date time matches the beginning date time of the first granule in the collection (if granules exist.)
+
+#### `validate_ending_datetime_against_granules`
+
+Checks whether the ending date time matches the ending date time of the last granule in the collection (if granules exist.)
+
+### GCMD Checks
+
+#### `science_keywords_gcmd_check`
+
+Check to determine if the provided science keyword matches a value from the GCMD controlled vocabulary list.
+
+#### `spatial_keyword_gcmd_check`
+
+Check to determine if the provided spatial keyword matches a value from the GCMD controlled vocabulary list.
+
+#### `platform_long_name_gcmd_check`
+
+Check to determine if the provided long name matches a value from the platform GCMD controlled vocabulary list.
+
+#### `platform_short_name_gcmd_check`
+
+Check to determine if the provided short name matches a value from the platform GCMD controlled vocabulary list.
+
+#### `platform_type_gcmd_check`
+
+Check to determine if the provided platform type matches a value from the GCMD controlled vocabulary list.
+
+#### `instrument_long_name_gcmd_check`
+
+Check to determine if the provided long name matches a value from the GCMD controlled vocabulary list.
+
+#### `instrument_short_name_gcmd_check`
+
+Check to determine if the provided short name matches a value from the GCMD controlled vocabulary list.
+
+#### `instrument_short_long_name_consistency_check`
+
+Checks if the provided instrument short name and long name are consistent across the GCMD keywords list.
+
+#### `campaign_long_name_gcmd_check`
+
+Checks whether the value adheres to GCMD, specifically the project list long name column.
+
+#### `campaign_short_name_gcmd_check`
+
+Checks whether the value adheres to GCMD, specifically the project list short name column.
+
+#### `campaign_short_long_name_consistency_check`
+
+Checks whether the campaign  (project) short name and long name GCMD keywords are consistent: basically that they belong to the same row.
+
+#### `data_center_short_name_gcmd_check`
+
+Checks whether the value adheres to GCMD, specifically the provider list short name column.
+
+#### `data_format_gcmd_check`
+
+Checks whether the value adheres to GCMD, specifically the data format short name/long name column.
+
+#### `online_resource_type_gcmd_check`
+
+Check that the `Online Resource Type` is included in the `rucontenttype` GCMD list under the `Type` or `Subtype` column.

--- a/pyQuARC/code/checker.py
+++ b/pyQuARC/code/checker.py
@@ -107,7 +107,7 @@ class Checker:
         msg_type can be any one of 'failure', 'remediation'
         """
         messages = self.messages_override.get(rule_id) or self.messages.get(rule_id)
-        return messages[msg_type]
+        return messages[msg_type] if messages else ''
 
     def build_message(self, result, rule_id):
         """
@@ -158,10 +158,10 @@ class Checker:
         Run the check function for `rule_id` and update `result_dict`
         """
         dependencies = rule.get("dependencies", [])
-        external_data = rule.get("data", [])
         rule_mapping = self.rules_override.get(
             rule_id
         ) or self.rule_mapping.get(rule_id)
+        external_data = rule_mapping.get("data", [])
         list_of_fields_to_apply = \
             rule_mapping.get("fields_to_apply").get(self.metadata_format, {})
         for field_dict in list_of_fields_to_apply:

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -359,6 +359,38 @@
         },
         "remediation": "Please provide a value for the provided characteristic. "
     },
+    "characteristic_name_length_check": {
+        "failure": "The characteristic name has invalid length.",
+        "help": {
+            "message": "",
+            "url": ""
+        },
+        "remediation": "Please provide a name that is a string between 1 and 80 characters."
+    },
+    "characteristic_desc_length_check": {
+        "failure": "A characteristic description has invalid length. ",
+        "help": {
+            "message": "",
+            "url": ""
+        },
+        "remediation": "Please provide a short description that is a string between 1 and 2048 characters"
+    },
+    "characteristic_unit_length_check": {
+        "failure": "A characteristic unit has invalid length.",
+        "help": {
+            "message": "",
+            "url": ""
+        },
+        "remediation": "Please provide a unit that is a string between 1 and 80 characters."
+    },
+    "characteristic_value_length_check": {
+        "failure": "A characteristic value has invalid length. ",
+        "help": {
+            "message": "",
+            "url": ""
+        },
+        "remediation": "Please provide a value that is a string between 1 and 80 characters."
+    },
     "mime_type_check": {
         "failure": "MimeType isn't valid.",
         "help": {

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -19,18 +19,14 @@
         "check_function": "health_and_status_check",
         "available": true
     },
-    "shortname_uniqueness": {
+    "string_compare": {
         "data_type": "string",
         "check_function": "compare",
         "available": true
     },
-    "abstract_length_check": {
+    "length_check": {
         "data_type": "string",
         "check_function": "length_check",
-        "data": [
-            100,
-            "gte"
-        ],
         "available": true
     },
     "doi_validity_check": {
@@ -38,82 +34,14 @@
         "check_function": "doi_check",
         "available": true
     },
-    "processing_level_id_check": {
+    "controlled_keywords_check": {
         "data_type": "string",
         "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "0",
-                "1A",
-                "1B",
-                "2",
-                "3",
-                "4"
-            ]
-        ],
         "available": true
     },
     "science_keywords_gcmd_check": {
         "data_type": "string",
         "check_function": "science_keywords_gcmd_check",
-        "available": true
-    },
-    "eosdis_doi_authority_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "https://doi.org",
-                "https://doi.org/"
-            ]
-        ],
-        "available": true
-    },
-    "delete_time_check": {
-        "data_type": "datetime",
-        "check_function": "compare",
-        "dependencies": [
-            [
-                "datetime_format_check"
-            ]
-        ],
-        "data": [
-            "now",
-            "gte"
-        ],
-        "available": true
-    },
-    "doi_missing_reason_enumeration_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "Not Applicable"
-            ]
-        ],
-        "available": true
-    },
-    "processing_level_description_length_check": {
-        "data_type": "string",
-        "check_function": "length_check",
-        "data": [
-            50,
-            "gte"
-        ],
-        "available": true
-    },
-    "umm_controlled_collection_state_list_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "ACTIVE",
-                "PLANNED",
-                "COMPLETE",
-                "NOT APPLICABLE",
-                "NOT PROVIDED"
-            ]
-        ],
         "available": true
     },
     "ends_at_present_flag_logic_check": {
@@ -126,206 +54,19 @@
         "check_function": "ends_at_present_flag_presence_check",
         "available": true
     },
-    "contact_mechanism_enum_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "Direct Line",
-                "Email",
-                "Facebook",
-                "Fax",
-                "Mobile",
-                "Modem",
-                "Primary",
-                "TDD/TTY Phone",
-                "Telephone",
-                "Twitter",
-                "U.S. toll free",
-                "Other"
-            ]
-        ],
-        "available": true
-    },
-    "data_contact_role_enum_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "Data Center Contact",
-                "Technical Contact",
-                "Science Contact",
-                "Investigator",
-                "Metadata Author",
-                "User Services",
-                "Science Software Development"
-            ]
-        ],
-        "available": true
-    },
-    "controlled_contact_role_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "ARCHIVER",
-                "DISTRIBUTOR",
-                "PROCESSOR",
-                "ORIGINATOR"
-            ]
-        ],
-        "available": true
-    },
-    "data_type_control_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "STRING",
-                "FLOAT",
-                "INT",
-                "BOOLEAN",
-                "DATE",
-                "TIME",
-                "DATETIME",
-                "DATE_STRING",
-                "TIME_STRING",
-                "DATETIME_STRING"
-            ]
-        ],
-        "available": true
-    },
-    "characteristic_name_check": {
+    "availability_check": {
         "data_type": "custom",
         "check_function": "availability_check",
-        "available": true
-    },
-    "characteristic_desc_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
-        "available": true
-    },
-    "characteristic_unit_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
-        "available": true
-    },
-    "characteristic_value_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
-        "available": true
-    },
-    "characteristic_name_length_check": {
-        "data_type": "string",
-        "check_function": "length_check",
-        "data": [
-            80,
-            "lte"
-        ],
-        "available": true
-    },
-    "characteristic_desc_length_check": {
-        "data_type": "string",
-        "check_function": "length_check",
-        "data": [
-            2048,
-            "lte"
-        ],
-        "available": true
-    },
-    "characteristic_unit_length_check": {
-        "data_type": "string",
-        "check_function": "length_check",
-        "data": [
-            80,
-            "lte"
-        ],
-        "available": true
-    },
-    "characteristic_value_length_check": {
-        "data_type": "string",
-        "check_function": "length_check",
-        "data": [
-            80,
-            "lte"
-        ],
         "available": true
     },
     "mime_type_check": {
         "data_type": "custom",
         "check_function": "mime_type_check",
-        "data": [
-            [
-                "application/json",
-                "application/xml",
-                "application/x-netcdf",
-                "application/gml+xml",
-                "application/vnd.google-earth.kml+xml",
-                "image/gif",
-                "image/tiff",
-                "image/bmp",
-                "text/csv",
-                "text/xml",
-                "application/pdf",
-                "application/x-hdf",
-                "application/xhdf5",
-                "application/octet-stream",
-                "application/vnd.google-earth.kmz",
-                "image/jpeg",
-                "image/png",
-                "image/vnd.collada+xml",
-                "text/html",
-                "text/plain",
-                "Not provided"
-            ]
-        ],
-        "available": true
-    },
-    "coordinate_system_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "CARTESIAN",
-                "GEODETIC"
-            ]
-        ],
-        "available": true
-    },
-    "product_flag_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "DATA_PRODUCT_FILE",
-                "INSTRUMENT_ANCILLARY_FILE",
-                "SYSTEM/SPACECRAFT_FILE",
-                "EXTERNAL_DATA"
-            ]
-        ],
-        "available": true
-    },
-    "granule_spatial_representation_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "CARTESIAN",
-                "GEODETIC",
-                "ORBIT",
-                "NO_SPATIAL"
-            ]
-        ],
         "available": true
     },
     "data_center_short_name_gcmd_check": {
         "data_type": "string",
         "check_function": "data_center_short_name_gcmd_check",
-        "available": true
-    },
-    "instrument_short_name_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
         "available": true
     },
     "instrument_short_long_name_consistency_check": {
@@ -403,28 +144,7 @@
         "check_function": "data_format_gcmd_check",
         "available": true
     },
-    "version_description_not_provided": {
-        "data_type": "string",
-        "check_function": "compare",
-        "data": [
-            "NOT PROVIDED",
-            "neq"
-        ],
-        "available": true
-    },
-    "collection_data_type_enumeration_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "SCIENCE_QUALITY",
-                "NEAR_REAL_TIME",
-                "OTHER"
-            ]
-        ],
-        "available": true
-    },
-    "data_center_name_presence_check": {
+    "presence_check": {
         "data_type": "custom",
         "check_function": "presence_check",
         "available": true
@@ -432,27 +152,6 @@
     "doi_link_update": {
         "data_type": "url",
         "check_function": "doi_link_update",
-        "data": [
-            [
-                "dx.doi.org",
-                "http://dx.doi.org",
-                "https://dx.doi.org"
-            ]
-        ],
-        "available": true
-    },
-    "vertical_spatial_domain_type_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "Atmosphere Layer",
-                "Maximum Altitude",
-                "Maximum Depth",
-                "Minimum Altitude",
-                "Minimum Depth"
-            ]
-        ],
         "available": true
     },
     "bounding_coordinate_logic_check": {
@@ -460,106 +159,9 @@
         "check_function": "bounding_coordinate_logic_check",
         "available": true
     },
-    "spatial_coverage_type_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "HORIZONTAL",
-                "VERTICAL",
-                "ORBITAL",
-                "HORIZONTAL_VERTICAL",
-                "ORBITAL_VERTICAL",
-                "HORIZONTAL_ORBITAL",
-                "HORIZONTAL_VERTICAL_ORBITAL"
-            ]
-        ],
-        "available": true
-    },
-    "depth_unit_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "Fathoms",
-                "Feet",
-                "HectoPascals",
-                "Meters",
-                "Millibars"
-            ]
-        ],
-        "available": true
-    },
-    "altitude_unit_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "HectoPascals",
-                "Kilometers",
-                "Millibars"
-            ]
-        ],
-        "available": true
-    },
-    "campaign_name_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "spatial_coverage_type_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "horizontal_datum_name_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "online_access_url_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "online_resource_url_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "online_access_url_description_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "online_resource_url_description_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
     "opendap_url_location_check": {
         "data_type": "custom",
         "check_function": "opendap_url_location_check",
-        "available": true
-    },
-    "location_keyword_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "spatial_extent_requirement_fulfillment_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "license_information_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "collection_citation_presence_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
         "available": true
     },
     "user_services_check": {
@@ -587,11 +189,6 @@
         "check_function": "online_resource_type_gcmd_check",
         "available": true
     },
-    "online_resource_type_presence_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
-        "available": true
-    },
     "characteristic_name_uniqueness_check": {
         "data_type": "custom",
         "check_function": "characteristic_name_uniqueness_check",
@@ -617,90 +214,9 @@
         ],
         "available": true
     },
-    "future_date_check": {
-        "data_type": "datetime",
-        "check_function": "compare",
-        "dependencies": [
-            [
-                "datetime_format_check"
-            ]
-        ],
-        "data": [
-            "now",
-            "gte"
-        ],
-        "available": true
-    },
-    "iso_topic_category_check": {
-        "data_type": "string",
-        "check_function": "controlled_keywords_check",
-        "data": [
-            [
-                "BIOTA",
-                "BOUNDARIES",
-                "CLIMATOLOGY/METEOROLOGY/ATMOSPHERE",
-                "DISASTER",
-                "ECONOMY",
-                "ELEVATION",
-                "ENVIRONMENT",
-                "EXTRA TERRESTRIAL",
-                "FARMING",
-                "GEOSCIENTIFIC INFORMATION",
-                "HEALTH",
-                "IMAGERY/BASE MAPS/EARTH COVER",
-                "INLAND WATERS",
-                "INTELLIGENCE/MILITARY",
-                "LOCATION",
-                "OCEANS",
-                "PLANNING CADASTRE",
-                "SOCIETY",
-                "STRUCTURE",
-                "TRANSPORTATION",
-                "UTILITIES/COMMUNICATIONS"
-            ]
-        ],
-        "available": true
-    },
     "dif10_date_not_provided_check": {
         "data_type": "string",
         "check_function": "compare",
-        "data": [
-            "NOT PROVIDED",
-            "neq"
-        ],
-        "available": true
-    },
-    "temporal_extent_requirement_check": {
-        "data_type": "custom",
-        "check_function": "presence_check",
-        "available": true
-    },
-    "ftp_protocol_check": {
-        "data_type": "string",
-        "check_function": "compare",
-        "data": [
-            "FTP",
-            "neq"
-        ],
-        "available": true
-    },
-    "citation_version_check": {
-        "data_type": "string",
-        "check_function": "compare",
-        "available": true
-    },
-    "default_date_check": {
-        "data_type": "datetime",
-        "check_function": "compare",
-        "data": [
-            "1970-01-01T00:00:00Z",
-            "neq"
-        ],
-        "available": true
-    },
-    "url_desc_presence_check": {
-        "data_type": "custom",
-        "check_function": "availability_check",
         "available": true
     },
     "get_data_url_check": {

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -214,11 +214,6 @@
         ],
         "available": true
     },
-    "dif10_date_not_provided_check": {
-        "data_type": "string",
-        "check_function": "compare",
-        "available": true
-    },
     "get_data_url_check": {
         "data_type": "custom",
         "check_function": "get_data_url_check",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -2000,7 +2000,8 @@
             "NOT PROVIDED",
             "neq"
         ],
-        "severity": "info"
+        "severity": "info",
+        "check_id": "string_compare"
     },
     "temporal_extent_requirement_check": {
         "rule_name": "Temporal Extent Requirement Check",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -352,7 +352,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "url_check"
     },
     "shortname_uniqueness": {
         "rule_name": "Short Name uniqueness check",
@@ -376,7 +377,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "string_compare"
     },
     "abstract_length_check": {
         "rule_name": "Abstract length check",
@@ -396,7 +398,12 @@
                 }
             ]
         },
-        "severity": "warning"
+        "data": [
+            100,
+            "gte"
+        ],
+        "severity": "warning",
+        "check_id": "length_check"
     },
     "doi_validity_check": {
         "rule_name": "DOI Validity Check",
@@ -426,7 +433,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "doi_validity_check"
     },
     "doi_link_update": {
         "rule_name": "DOI Link Update",
@@ -446,6 +454,13 @@
                 }
             ]
         },
+        "data": [
+            [
+                "dx.doi.org",
+                "http://dx.doi.org",
+                "https://dx.doi.org"
+            ]
+        ],
         "severity": "info"
     },
     "processing_level_id_check": {
@@ -466,7 +481,18 @@
                 }
             ]
         },
-        "severity": "warning"
+        "data": [
+            [
+                "0",
+                "1A",
+                "1B",
+                "2",
+                "3",
+                "4"
+            ]
+        ],
+        "severity": "warning",
+        "check_id": "controlled_keywords_check"
     },
     "science_keywords_gcmd_check": {
         "rule_name": "GCMD Science keywords check",
@@ -509,7 +535,14 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            [
+                "https://doi.org",
+                "https://doi.org/"
+            ]
+        ],
+        "severity": "info",
+        "check_id": "controlled_keywords_check"
     },
     "delete_time_check": {
         "rule_name": "Delete Time Check",
@@ -534,7 +567,12 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            "now",
+            "gte"
+        ],
+        "severity": "info",
+        "check_id": "date_compare"
     },
     "doi_missing_reason_enumeration_check": {
         "rule_name": "DOI Missing Reason Enumeration Check",
@@ -547,7 +585,13 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "Not Applicable"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "processing_level_description_length_check": {
         "rule_name": "Processing Level Description Length Check",
@@ -560,7 +604,12 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            50,
+            "gte"
+        ],
+        "severity": "info",
+        "check_id": "length_check"
     },
     "umm_controlled_collection_state_list_check": {
         "rule_name": "UMM Controlled Collection State List",
@@ -573,7 +622,17 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "ACTIVE",
+                "PLANNED",
+                "COMPLETE",
+                "NOT APPLICABLE",
+                "NOT PROVIDED"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "ends_at_present_flag_logic_check": {
         "rule_name": "Ends at present flag logic check",
@@ -634,7 +693,24 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "Direct Line",
+                "Email",
+                "Facebook",
+                "Fax",
+                "Mobile",
+                "Modem",
+                "Primary",
+                "TDD/TTY Phone",
+                "Telephone",
+                "Twitter",
+                "U.S. toll free",
+                "Other"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "data_contact_role_enum_check": {
         "rule_name": "Data Contact Role Enumeration Check",
@@ -647,7 +723,19 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "Data Center Contact",
+                "Technical Contact",
+                "Science Contact",
+                "Investigator",
+                "Metadata Author",
+                "User Services",
+                "Science Software Development"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "controlled_contact_role_check": {
         "rule_name": "Controlled Contact Role Check",
@@ -660,7 +748,16 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "ARCHIVER",
+                "DISTRIBUTOR",
+                "PROCESSOR",
+                "ORIGINATOR"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "data_type_control_check": {
         "rule_name": "Data type control Check",
@@ -688,7 +785,22 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "STRING",
+                "FLOAT",
+                "INT",
+                "BOOLEAN",
+                "DATE",
+                "TIME",
+                "DATETIME",
+                "DATE_STRING",
+                "TIME_STRING",
+                "DATETIME_STRING"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "characteristic_name_check": {
         "rule_name": "Characteristic Name Check",
@@ -710,7 +822,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "availability_check"
     },
     "characteristic_desc_check": {
         "rule_name": "Characteristic Description Check",
@@ -732,7 +845,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "availability_check"
     },
     "characteristic_unit_check": {
         "rule_name": "Characteristic Unit Check",
@@ -754,7 +868,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "availability_check"
     },
     "characteristic_value_check": {
         "rule_name": "Characteristic Value Check",
@@ -776,7 +891,109 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "availability_check"
+    },
+    "characteristic_name_length_check": {
+        "rule_name": "Characteristic Name Length Check",
+        "fields_to_apply": {
+            "echo10": [
+                {
+                    "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Characteristics/Characteristic/Name"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Platform/Characteristics/Name"
+                    ]
+                }
+            ]
+        },
+
+      "data": [
+        80,
+        "lte"
+    ],
+        "severity": "error",
+        "check_id": "length_check"
+    },
+    "characteristic_desc_length_check": {
+        "rule_name": "Characteristic Description Length Check",
+        "fields_to_apply": {
+            "echo10": [
+                {
+                    "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Characteristics/Characteristic/Description"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Platform/Characteristics/Description"
+                    ]
+                }
+            ]
+        },
+        "data": [
+            2048,
+            "lte"
+        ],
+        "severity": "error",
+        "check_id": "length_check"
+    },
+    "characteristic_unit_length_check": {
+        "rule_name": "Characteristic Unit Length Check",
+        "fields_to_apply": {
+            "echo10": [
+                {
+                    "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Characteristics/Characteristic/Unit"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Platform/Characteristics/Unit"
+                    ]
+                }
+            ]
+        },
+        "data": [
+            80,
+            "lte"
+        ],
+        "severity": "error",
+        "check_id": "length_check"
+    },
+    "characteristic_value_length_check": {
+        "rule_name": "Characteristic Value Length Check",
+        "fields_to_apply": {
+            "echo10": [
+                {
+                    "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Characteristics/Characteristic/Value"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Platform/Characteristics/Value"
+                    ]
+                }
+            ]
+        },
+        "data": [
+            80,
+            "lte"
+        ],
+        "severity": "error",
+        "check_id": "length_check"
     },
     "mime_type_check": {
         "rule_name": "MIME type Check",
@@ -798,6 +1015,31 @@
                 }
             ]
         },
+        "data": [
+            [
+                "application/json",
+                "application/xml",
+                "application/x-netcdf",
+                "application/gml+xml",
+                "application/vnd.google-earth.kml+xml",
+                "image/gif",
+                "image/tiff",
+                "image/bmp",
+                "text/csv",
+                "text/xml",
+                "application/pdf",
+                "application/x-hdf",
+                "application/xhdf5",
+                "application/octet-stream",
+                "application/vnd.google-earth.kmz",
+                "image/jpeg",
+                "image/png",
+                "image/vnd.collada+xml",
+                "text/html",
+                "text/plain",
+                "Not provided"
+            ]
+        ],
         "severity": "info"
     },
     "coordinate_system_check": {
@@ -811,7 +1053,14 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "CARTESIAN",
+                "GEODETIC"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "product_flag_check": {
         "rule_name": "Product Flag Check",
@@ -824,7 +1073,16 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "DATA_PRODUCT_FILE",
+                "INSTRUMENT_ANCILLARY_FILE",
+                "SYSTEM/SPACECRAFT_FILE",
+                "EXTERNAL_DATA"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "granule_spatial_representation_check": {
         "rule_name": "Granule Spatial Representation Check",
@@ -837,7 +1095,16 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "CARTESIAN",
+                "GEODETIC",
+                "ORBIT",
+                "NO_SPATIAL"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "data_center_short_name_gcmd_check": {
         "rule_name": "Data Center Shortname GCMD Check",
@@ -1076,7 +1343,12 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            "NOT PROVIDED",
+            "neq"
+        ],
+        "severity": "info",
+        "check_id": "string_compare"
     },
     "collection_data_type_enumeration_check": {
         "rule_name": "Collection Data Type Enumeration Check",
@@ -1089,7 +1361,15 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "SCIENCE_QUALITY",
+                "NEAR_REAL_TIME",
+                "OTHER"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "data_center_name_presence_check": {
         "rule_name": "Data Center Name Presence Check",
@@ -1104,7 +1384,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "bounding_coordinate_logic_check": {
         "rule_name": "Bounding Coordinates Logic Check",
@@ -1130,7 +1411,17 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "Atmosphere Layer",
+                "Maximum Altitude",
+                "Maximum Depth",
+                "Minimum Altitude",
+                "Minimum Depth"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "spatial_coverage_type_check": {
         "rule_name": "Spatial Coverage Type Check",
@@ -1148,7 +1439,19 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "HORIZONTAL",
+                "VERTICAL",
+                "ORBITAL",
+                "HORIZONTAL_VERTICAL",
+                "ORBITAL_VERTICAL",
+                "HORIZONTAL_ORBITAL",
+                "HORIZONTAL_VERTICAL_ORBITAL"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "depth_unit_check": {
         "rule_name": "Depth Unit Controlled Vocabulary Check",
@@ -1168,7 +1471,17 @@
                 }
             ]
         },
-        "severity": "warning"
+        "data": [
+            [
+                "Fathoms",
+                "Feet",
+                "HectoPascals",
+                "Meters",
+                "Millibars"
+            ]
+        ],
+        "severity": "warning",
+        "check_id": "controlled_keywords_check"
     },
     "altitude_unit_check": {
         "rule_name": "Altitude Unit Controlled Vocabulary Check",
@@ -1188,7 +1501,15 @@
                 }
             ]
         },
-        "severity": "warning"
+        "data": [
+            [
+                "HectoPascals",
+                "Kilometers",
+                "Millibars"
+            ]
+        ],
+        "severity": "warning",
+        "check_id": "controlled_keywords_check"
     },
     "campaign_name_presence_check": {
         "rule_name": "Campaign Name Presence Check",
@@ -1208,7 +1529,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "spatial_coverage_type_presence_check": {
         "rule_name": "Spatial Coverage Type Presence Check",
@@ -1221,7 +1543,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "horizontal_datum_name_check": {
         "rule_name": "Horizontal Datum Name Check",
@@ -1241,7 +1564,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "online_access_url_presence_check": {
         "rule_name": "Online Access URL Presence Check",
@@ -1254,7 +1578,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "presence_check"
     },
     "online_resource_url_presence_check": {
         "rule_name": "Online Resource URL Presence Check",
@@ -1267,7 +1592,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "presence_check"
     },
     "online_access_url_description_check": {
         "rule_name": "Online Access URL Description Check",
@@ -1280,7 +1606,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "online_resource_url_description_check": {
         "rule_name": "Online Resource URL Description Check",
@@ -1293,7 +1620,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "opendap_url_location_check": {
         "rule_name": "ECHO10 OPeNDAP URL Location Check",
@@ -1306,7 +1634,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "opendap_url_location_check"
     },
     "location_keyword_presence_check": {
         "rule_name": "Location Keyword Presence Check",
@@ -1326,7 +1655,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "spatial_extent_requirement_fulfillment_check": {
         "rule_name": "Spatial Extent Requirement Fulfillment Check",
@@ -1342,7 +1672,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "license_information_check": {
         "rule_name": "License Information Check",
@@ -1363,7 +1694,8 @@
                 }
             ]
         },
-        "severity": "warning"
+        "severity": "warning",
+        "check_id": "presence_check"
     },
     "collection_citation_presence_check": {
         "rule_name": "Collection Citation Presence Check",
@@ -1383,7 +1715,8 @@
                 }
             ]
         },
-        "severity": "warning"
+        "severity": "warning",
+        "check_id": "presence_check"
     },
     "user_services_check": {
         "rule_name": "User Services Check",
@@ -1398,7 +1731,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "user_services_check"
     },
     "doi_missing_reason_explanation": {
         "rule_name": "DOI Missing Reason Explanation",
@@ -1422,7 +1756,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "doi_missing_reason_explanation"
     },
     "boolean_check": {
         "rule_name": "Boolean check",
@@ -1440,7 +1775,8 @@
                 }
             ]
         },
-        "severity": "error"
+        "severity": "error",
+        "check_id": "boolean_check"
     },
     "collection_progress_consistency_check": {
         "rule_name": "Collection Progress Related Fields Consistency Check",
@@ -1464,7 +1800,8 @@
                 }
             ]
         },
-        "severity": "warning"
+        "severity": "warning",
+        "check_id": "collection_progress_consistency_check"
     },
     "online_resource_type_gcmd_check": {
         "rule_name": "Online Resource Type GCMD Check",
@@ -1491,7 +1828,8 @@
                 }
             ]
         },
-        "severity": "warning"
+        "severity": "warning",
+        "check_id": "availability_check"
     },
     "characteristic_name_uniqueness_check": {
         "rule_name": "Characteristic Name Uniqueness Check",
@@ -1504,7 +1842,8 @@
                 }
             ]
         },
-        "severity": "warning"
+        "severity": "warning",
+        "check_id": "characteristic_name_uniqueness_check"
     },
     "validate_ending_datetime_against_granules": {
         "rule_name": "Ending Datetime validation against granules",
@@ -1566,7 +1905,12 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            "now",
+            "gte"
+        ],
+        "severity": "info",
+        "check_id": "date_compare"
     },
     "iso_topic_category_check": {
         "rule_name": "ISO Topic Category Vocabulary Check",
@@ -1579,7 +1923,33 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            [
+                "BIOTA",
+                "BOUNDARIES",
+                "CLIMATOLOGY/METEOROLOGY/ATMOSPHERE",
+                "DISASTER",
+                "ECONOMY",
+                "ELEVATION",
+                "ENVIRONMENT",
+                "EXTRA TERRESTRIAL",
+                "FARMING",
+                "GEOSCIENTIFIC INFORMATION",
+                "HEALTH",
+                "IMAGERY/BASE MAPS/EARTH COVER",
+                "INLAND WATERS",
+                "INTELLIGENCE/MILITARY",
+                "LOCATION",
+                "OCEANS",
+                "PLANNING CADASTRE",
+                "SOCIETY",
+                "STRUCTURE",
+                "TRANSPORTATION",
+                "UTILITIES/COMMUNICATIONS"
+            ]
+        ],
+        "severity": "error",
+        "check_id": "controlled_keywords_check"
     },
     "dif10_date_not_provided_check": {
         "rule_name": "DIF10 Date Not Provided Check",
@@ -1626,6 +1996,10 @@
                 }
             ]
         },
+        "data": [
+            "NOT PROVIDED",
+            "neq"
+        ],
         "severity": "info"
     },
     "temporal_extent_requirement_check": {
@@ -1650,7 +2024,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "presence_check"
     },
     "ftp_protocol_check": {
         "rule_name": "FTP Protocol Check",
@@ -1668,7 +2043,12 @@
                 }
             ]
         },
-        "severity": "error"
+        "data": [
+            "FTP",
+            "neq"
+        ],
+        "severity": "error",
+        "check_id": "string_compare"
     },
     "citation_version_check": {
         "rule_name": "Citation Version Check",
@@ -1683,7 +2063,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "string_compare"
     },
     "default_date_check": {
         "rule_name": "Default Date Check",
@@ -1731,7 +2112,12 @@
                 }
             ]
         },
-        "severity": "info"
+        "data": [
+            "1970-01-01T00:00:00Z",
+            "neq"
+        ],
+        "severity": "info",
+        "check_id": "date_compare"
     },
     "url_desc_presence_check": {
         "rule_name": "Online Description Presence Check",
@@ -1771,7 +2157,8 @@
                 }
             ]
         },
-        "severity": "info"
+        "severity": "info",
+        "check_id": "availability_check"
     },
     "get_data_url_check": {
         "rule_name": "GET DATA URL check",


### PR DESCRIPTION
**Motivation**
To make pyQuARC easier for the users, it is set up in a way that a new rule can be added just by adding entries to a set of JSON files. A new rule basically points to a checks that is already implemented. 

We need documentation of all the available checks so the user can just go through it and find the check that they need to create the new rule. It should include the description of what the check does and the check id that can be used in the JSON files.

**Changes made**
Restructured the schema files `rule_mapping.json` and `checks.json`, such that the `checks` can be reused and users have to only make changes in the `rule_mapping.json` file.
Changes include:
- Moved `data` from `checks.json` to `rule_mapping.json`
- Added `check_id` to `rule_mapping.json` to point to already existing check (helps remove duplicates from `checks.json`)
- Removed the duplicate checks from `checks.json`

**Deliverable**
The documentation for all the available checks is provided in the file [CHECKS.md](https://github.com/NASA-IMPACT/pyQuARC/blob/feature-documentation/CHECKS.md)