### PR TITLE
Fix dependencies bug

### DIFF
--- a/pyQuARC/code/gcmd_validator.py
+++ b/pyQuARC/code/gcmd_validator.py
@@ -208,9 +208,10 @@ class GcmdValidator:
         """
         Validates GCMD instrument short name and long name consistency
         """
-        return GcmdValidator.validate_recursively(
+        validity, _ = GcmdValidator.validate_recursively(
             self.keywords["instrument"], input_keyword
         )
+        return validity
 
     def validate_instrument_short_name(self, input_keyword):
         """
@@ -258,9 +259,10 @@ class GcmdValidator:
         """
         Validates GCMD campaign short name and long name consistency
         """
-        return GcmdValidator.validate_recursively(
+        validity, _ = GcmdValidator.validate_recursively(
             self.keywords["campaign"], input_keyword
         )
+        return validity
 
     def validate_campaign_short_name(self, input_keyword):
         """

--- a/pyQuARC/code/scheduler.py
+++ b/pyQuARC/code/scheduler.py
@@ -3,11 +3,12 @@ class Scheduler:
     Schedules the rules based on the applicable ordering
     """
 
-    def __init__(self, rule_mapping, rules_override, checks, checks_override):
+    def __init__(self, rule_mapping, rules_override, checks, checks_override, metadata_format):
         self.check_list = checks
         self.checks_override = checks_override
         self.rule_mapping = rule_mapping
         self.rules_override = rules_override
+        self.metadata_format = metadata_format
 
     @staticmethod
     def append_if_not_exist(value, list_of_values):
@@ -18,6 +19,25 @@ class Scheduler:
         if value not in list_of_values:
             list_of_values.append(value)
 
+    def get_all_dependencies(self, rule_id, check, field_dict=None):
+        dependencies = []
+        dependencies_from_fields = []
+
+        if not field_dict:
+            rule = self.rule_mapping.get(rule_id)
+            if field_objects := rule.get("fields_to_apply").get(self.metadata_format):
+                for field_object in field_objects:
+                    if field_dependencies := field_object.get("dependencies"):
+                        dependencies_from_fields.extend(field_dependencies)
+        else:
+            dependencies_from_fields = field_dict.get("dependencies", [])
+
+        dependencies.extend(dependencies_from_fields)
+
+        dependencies_from_checks = check.get("dependencies", [])
+        dependencies.extend(dependencies_from_checks)
+        return dependencies
+
     def _add_to_list(self, rule_id, rule, rules_list):
         """
         Adds `rule` to `rules_list` based on the dependency order
@@ -26,7 +46,7 @@ class Scheduler:
         if check := self.checks_override.get(
             check_id
         ) or self.check_list.get(check_id):
-            dependencies = check.get("dependencies", [])
+            dependencies = self.get_all_dependencies(rule_id, check)
             for dependency in dependencies:
                 check = self.rules_override.get(
                     dependency[0]

--- a/pyQuARC/code/string_validator.py
+++ b/pyQuARC/code/string_validator.py
@@ -106,7 +106,7 @@ class StringValidator(BaseValidator):
             "valid": StringValidator.gcmdValidator.validate_instrument_short_long_name_consistency(
                 received_keyword
             ),
-            "value": [args[0], args[1]],
+            "value": (args[0], args[1]),
         }
 
     @staticmethod
@@ -176,7 +176,7 @@ class StringValidator(BaseValidator):
         return {
             "valid": StringValidator.gcmdValidator.validate_campaign_short_long_name_consistency(
                 received_keyword
-            )[0],
+            ),
             "value": (args[0], args[1]),
         }
 

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -72,16 +72,6 @@
     "instrument_short_long_name_consistency_check": {
         "data_type": "string",
         "check_function": "instrument_short_long_name_consistency_check",
-        "dependencies": [
-            [
-                "instrument_short_name_gcmd_check",
-                "Collection/Platforms/Platform/Instruments/Instrument/ShortName"
-            ],
-            [
-                "instrument_long_name_gcmd_check",
-                "Collection/Platforms/Platform/Instruments/Instrument/LongName"
-            ]
-        ],
         "available": true
     },
     "instrument_short_name_gcmd_check": {
@@ -117,16 +107,6 @@
     "campaign_short_long_name_consistency_check": {
         "data_type": "string",
         "check_function": "campaign_short_long_name_consistency_check",
-        "dependencies": [
-            [
-                "campaign_short_name_gcmd_check",
-                "Collection/Campaigns/Campaign/ShortName"
-            ],
-            [
-                "campaign_long_name_gcmd_check",
-                "Collection/Campaigns/Campaign/LongName"
-            ]
-        ],
         "available": true
     },
     "campaign_short_name_gcmd_check": {

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -1132,6 +1132,32 @@
                     "fields": [
                         "Collection/Platforms/Platform/Instruments/Instrument/ShortName",
                         "Collection/Platforms/Platform/Instruments/Instrument/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/ShortName"
+                        ],
+                        [
+                            "instrument_long_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/LongName"
+                        ]
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/ShortName",
+                        "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/ShortName"
+                        ],
+                        [
+                            "instrument_long_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/LongName"
+                        ]
                     ]
                 }
             ],
@@ -1140,6 +1166,16 @@
                     "fields": [
                         "DIF/Platform/Instrument/Short_Name",
                         "DIF/Platform/Instrument/Long_Name"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "DIF/Platform/Instrument/Short_Name"
+                        ],
+                        [
+                            "instrument_long_name_gcmd_check",
+                            "DIF/Platform/Instrument/Long_Name"
+                        ]
                     ]
                 }
             ]
@@ -1295,6 +1331,18 @@
                         "Collection/Campaigns/Campaign/LongName"
                     ]
                 }
+            ]
+        },
+        "dependencies": {
+            "echo10": [
+                [
+                    "campaign_short_name_gcmd_check",
+                    "Collection/Campaigns/Campaign/ShortName"
+                ],
+                [
+                    "campaign_long_name_gcmd_check",
+                    "Collection/Campaigns/Campaign/LongName"
+                ]
             ]
         },
         "severity": "error"


### PR DESCRIPTION
**Motivation**
The dependencies that are based on fields (not just checks) are not generic to all the checks. They change based on the fields supplied to the check. Thus, it doesn't work if it lives in `checks.json` (where it currently is). 

The solution is to move those to `rule_mapping.json` where the users can add such dependencies based on the fields that are supplied.

**Repercussions**
Users now will have to add these kind of field based dependencies in the `rule_mapping.json` file/override by themselves.