### PR TITLE
Include `version.txt` file in the package

### DIFF
--- a/pyQuARC/__init__.py
+++ b/pyQuARC/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from pyQuARC.main import ARC
 
 from pyQuARC.code.checker import Checker
@@ -9,8 +11,8 @@ from pyQuARC.code.schema_validator import SchemaValidator
 from pyQuARC.code.string_validator import StringValidator
 from pyQuARC.code.url_validator import UrlValidator
 
-
-with open("pyQuARC/version.txt") as version_file:
+ABS_PATH = os.path.abspath(os.path.dirname(__file__))
+with open(f"{ABS_PATH}/version.txt") as version_file:
     __version__ = version_file.read().strip()
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setuptools.setup(
     keywords='validation metadata cmr quality',
     python_requires='>=3.8',
     install_requires=requirements,
-    package_data={'pyQuARC': ['schemas/*'], 'tests': ['fixtures/*']},
+    package_data={'pyQuARC': ['schemas/*', '*.txt'], 'tests': ['fixtures/*']},
     include_package_data=True,
 )


### PR DESCRIPTION
Fixes the following error when importing the package:

```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.9/site-packages/pyQuARC-1.1.0-py3.9.egg/pyQuARC/version.txt'
```