### PR TITLE
Remove pathlib as requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ colorama==0.4.4
 idna==2.10
 jsonschema==3.2.0
 lxml==4.9.1
-pathlib==1.0.1
 pytest==5.4.3
 pytz==2020.1
 requests==2.24.0


### PR DESCRIPTION
Remove `pathlib` package as requirement. In python > 3.5 it overwrites the already installed pathlib. 