### PR TITLE
Update long name presence checks for instrument, platform, and campaign

### DIFF
--- a/pyQuARC/code/gcmd_validator.py
+++ b/pyQuARC/code/gcmd_validator.py
@@ -383,6 +383,13 @@ class GcmdValidator:
         """
         return input_keyword in self.keywords["campaign_long_name"]
 
+    def validate_campaign_long_name_presence(self, input_keyword):
+        """
+        Validates whether a given campaign short name has a corresponding long name
+        """
+        long_name_field = self.keywords["campaign"].get(input_keyword)
+        return "N/A" in long_name_field
+
     def validate_data_format(self, input_keyword):
         """
         Validates GCMD Granule Data Format

--- a/pyQuARC/code/gcmd_validator.py
+++ b/pyQuARC/code/gcmd_validator.py
@@ -288,6 +288,13 @@ class GcmdValidator:
         Validates GCMD instrument long name
         """
         return input_keyword in self.keywords["instrument_long_name"]
+    
+    def validate_instrument_long_name_presence(self, input_keyword):
+        """
+        Validates whether a given instrument short name has a corresponding long name
+        """
+        long_name_field = self.keywords["instrument"].get(input_keyword)
+        return "N/A" in long_name_field
 
     def validate_platform_short_name(self, input_keyword):
         """

--- a/pyQuARC/code/gcmd_validator.py
+++ b/pyQuARC/code/gcmd_validator.py
@@ -314,6 +314,13 @@ class GcmdValidator:
         """
         return input_keyword in self.keywords["platform_type"]
 
+    def validate_platform_long_name_presence(self, input_keyword):
+        """
+        Validates whether a given platform short name has a corresponding long name
+        """
+        long_name_field = self.keywords["platform"].get(input_keyword)
+        return "N/A" in long_name_field
+
     def validate_platform_short_long_name_consistency(self, input_keyword):
         """
         Validates GCMD platform short name and long name consistency

--- a/pyQuARC/code/string_validator.py
+++ b/pyQuARC/code/string_validator.py
@@ -161,6 +161,22 @@ class StringValidator(BaseValidator):
 
     @staticmethod
     @if_arg
+    def instrument_long_name_presence_check(*args):
+        if not args[1]:
+            return {
+                "valid": StringValidator.gcmdValidator.validate_instrument_long_name_presence(
+                    args[0].upper()
+                ),
+                "value": args[0],
+            }
+        else:
+            return {
+                "valid": True,
+                "value": args[0],
+            }
+
+    @staticmethod
+    @if_arg
     def platform_short_name_gcmd_check(value):
         return {
             "valid": StringValidator.gcmdValidator.validate_platform_short_name(

--- a/pyQuARC/code/string_validator.py
+++ b/pyQuARC/code/string_validator.py
@@ -275,6 +275,22 @@ class StringValidator(BaseValidator):
 
     @staticmethod
     @if_arg
+    def campaign_long_name_presence_check(*args):
+        if not args[1]:
+            return {
+                "valid": StringValidator.gcmdValidator.validate_campaign_long_name_presence(
+                    args[0].upper()
+                ),
+                "value": args[0],
+            }
+        else:
+            return {
+                "valid": True,
+                "value": args[0],
+            }
+
+    @staticmethod
+    @if_arg
     def data_format_gcmd_check(value):
         return {
             "valid": StringValidator.gcmdValidator.validate_data_format(value.upper()),

--- a/pyQuARC/code/string_validator.py
+++ b/pyQuARC/code/string_validator.py
@@ -207,6 +207,22 @@ class StringValidator(BaseValidator):
 
     @staticmethod
     @if_arg
+    def platform_long_name_presence_check(*args):
+        if not args[1]:
+            return {
+                "valid": StringValidator.gcmdValidator.validate_platform_long_name_presence(
+                    args[0].upper()
+                ),
+                "value": args[0],
+            }
+        else:
+            return {
+                "valid": True,
+                "value": args[0],
+            }
+
+    @staticmethod
+    @if_arg
     def platform_short_long_name_consistency_check(*args):
         received_keyword = [arg.upper().strip() for arg in args if arg]
         return {

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -425,7 +425,7 @@
         "remediation": "Select a valid long name, or submit a request to support@earthdata.nasa.gov to have this project/campaign name added to the GCMD Projects keyword list."
     },
     "campaign_long_name_presence_check": {
-        "failure": "The project/campaign long name is missing.",
+        "failure": "The provided project/campaign short name `{}` is missing the corresponding project/campaign long name.",
         "help": {
             "message": "",
             "url": ""

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -305,7 +305,7 @@
         "remediation": "Select a valid long name, or submit a request to support@earthdata.nasa.gov to have this instrument added to the GCMD Instruments keyword list."
     },
     "instrument_long_name_presence_check": {
-        "failure": "The instrument/sensor long name is missing.",
+        "failure": "The provided instrument/sensor short name `{}` is missing the corresponding instrument/sensor long name.",
         "help": {
             "message": "",
             "url": "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments/?format=csv&page_num=1&page_size=2000"

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -929,7 +929,7 @@
         "remediation": "Recommend adding a platform type for the corresponding platform."
     },
     "platform_long_name_presence_check": {
-        "failure": "A platform long name is not provided.",
+        "failure": "The provided platform short name `{}` is missing the corresponding platform long name.",
         "help": {
             "message": "",
             "url": "https://wiki.earthdata.nasa.gov/display/CMR/Platform"

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -164,6 +164,11 @@
         "check_function": "campaign_long_name_gcmd_check",
         "available": true
     },
+    "campaign_long_name_presence_check": {
+        "data_type": "string",
+        "check_function": "campaign_long_name_presence_check",
+        "available": true
+    },
     "data_format_gcmd_check": {
         "data_type": "string",
         "check_function": "data_format_gcmd_check",

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -99,6 +99,11 @@
         "check_function": "instrument_long_name_gcmd_check",
         "available": true
     },
+    "instrument_long_name_presence_check": {
+        "data_type": "string",
+        "check_function": "instrument_long_name_presence_check",
+        "available": true
+    },
     "validate_granule_instrument_against_collection": {
         "data_type": "string",
         "check_function": "validate_granule_instrument_against_collection",

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -124,6 +124,11 @@
         "check_function": "platform_type_gcmd_check",
         "available": true
     },
+    "platform_long_name_presence_check": {
+        "data_type": "string",
+        "check_function": "platform_long_name_presence_check",
+        "available": true
+    },
     "platform_short_long_name_consistency_check": {
         "data_type": "string",
         "check_function": "platform_short_long_name_consistency_check",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -2536,47 +2536,89 @@
         "check_id": "instrument_long_name_gcmd_check"
     },
     "instrument_long_name_presence_check": {
-        "rule_name": "Instrument Longname Presence Check",
+        "rule_name": "Instrument Longname Requirement Check",
         "fields_to_apply": {
             "echo-c": [
                 {
                     "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/ShortName",
                         "Collection/Platforms/Platform/Instruments/Instrument/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/ShortName"
+                        ]
                     ]
                 },
                 {
                     "fields": [
+                        "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/ShortName",
                         "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Collection/Platforms/Platform/Instruments/Instrument/Sensors/Sensor/ShortName"
+                        ]
                     ]
                 }
             ],
             "dif10": [
                 {
                     "fields": [
+                        "DIF/Platform/Instrument/Short_Name",
                         "DIF/Platform/Instrument/Long_Name"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "DIF/Platform/Instrument/Short_Name"
+                        ]
                     ]
                 },
                 {
                     "fields": [
+                        "DIF/Platform/Instrument/Sensor/Short_Name",
                         "DIF/Platform/Instrument/Sensor/Long_Name"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "DIF/Platform/Instrument/Sensor/Short_Name"
+                        ]
                     ]
                 }
             ],
             "umm-c": [
                 {
                     "fields": [
+                        "Platforms/Instruments/ShortName",
                         "Platforms/Instruments/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Platforms/Instruments/ShortName"
+                        ]
                     ]
                 },
                 {
                     "fields": [
+                        "Platforms/Instruments/ComposedOf/ShortName",
                         "Platforms/Instruments/ComposedOf/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "instrument_short_name_gcmd_check",
+                            "Platforms/Instruments/ComposedOf/ShortName"
+                        ]
                     ]
                 }
             ]
         },
         "severity": "warning",
-        "check_id": "one_item_presence_check"
+        "check_id": "instrument_long_name_presence_check"
     },
     "granule_instrument_presence_check": {
         "rule_name": "Granule Instrument Presence Check",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -3143,18 +3143,53 @@
         "check_id": "campaign_long_name_gcmd_check"
     },
     "campaign_long_name_presence_check": {
-        "rule_name": "Campaign Long Name Presence Check",
+        "rule_name": "Campaign Longname Requirement Check",
         "fields_to_apply": {
+            "echo-c": [
+                {
+                    "fields": [
+                        "Collection/Campaigns/Campaign/ShortName",
+                        "Collection/Campaigns/Campaign/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "campaign_short_name_gcmd_check",
+                            "Collection/Campaigns/Campaign/ShortName"
+                        ]
+                    ]
+                }
+            ],
             "dif10": [
                 {
                     "fields": [
+                        "DIF/Project/Short_Name",
                         "DIF/Project/Long_Name"
+                    ],
+                    "dependencies": [
+                        [
+                            "campaign_short_name_gcmd_check",
+                            "DIF/Project/Short_Name"
+                        ]
+                    ]
+                }
+            ],
+            "umm-c": [
+                {
+                    "fields": [
+                        "Projects/ShortName",
+                        "Projects/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "campaign_short_name_gcmd_check",
+                            "Projects/ShortName"
+                        ]
                     ]
                 }
             ]
         },
         "severity": "warning",
-        "check_id": "one_item_presence_check"
+        "check_id": "campaign_long_name_presence_check"
     },
     "version_description_not_provided": {
         "rule_name": "Version Description Not Provided",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -5083,32 +5083,53 @@
         "check_id": "one_item_presence_check"
     },
     "platform_long_name_presence_check": {
-        "rule_name": "Platform Longname Presence Check",
+        "rule_name": "Platform Longname Requirement Check",
         "fields_to_apply": {
             "echo-c": [
                 {
                     "fields": [
-                        "Collection/Platforms/Platforms/LongName"
+                        "Collection/Platforms/Platform/ShortName",
+                        "Collection/Platforms/Platform/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "platform_short_name_gcmd_check",
+                            "Collection/Platforms/Platform/ShortName"
+                        ]
                     ]
                 }
             ],
             "dif10": [
                 {
                     "fields": [
+                        "DIF/Platform/Short_Name",
                         "DIF/Platform/Long_Name"
+                    ],
+                    "dependencies": [
+                        [
+                            "platform_short_name_gcmd_check",
+                            "DIF/Platform/Short_Name"
+                        ]
                     ]
                 }
             ],
             "umm-c": [
                 {
                     "fields": [
+                        "Platforms/ShortName",
                         "Platforms/LongName"
+                    ],
+                    "dependencies": [
+                        [
+                            "platform_short_name_gcmd_check",
+                            "Platforms/ShortName"
+                        ]
                     ]
                 }
             ]
         },
         "severity": "warning",
-        "check_id": "one_item_presence_check"
+        "check_id": "platform_long_name_presence_check"
     },
     "granule_platform_presence_check": {
         "rule_name": "Granule Platform Presence Check",


### PR DESCRIPTION
Updated the long name presence checks for instrument, platform, and campaign to only display an error message when a long name exists in GCMD. Made changes to rule_mapping.json, checks.json, string_validator.py, gcmd_validator.py, and check_messages.json.