### PR TITLE
Refactor URL extraction logic in url_validator.py

### DIFF
--- a/pyQuARC/code/url_validator.py
+++ b/pyQuARC/code/url_validator.py
@@ -1,6 +1,5 @@
 import requests
-
-from urlextract import URLExtract
+import re
 
 from .string_validator import StringValidator
 from .utils import get_headers, if_arg
@@ -15,23 +14,20 @@ class UrlValidator(StringValidator):
         super().__init__()
 
     @staticmethod
-    def _extract_http_texts(text_with_urls):
+    def _extract_urls_from_texts(text_with_urls):
         """
-        Extracts anything that starts with 'http' from `text_with_urls`.
-        This is required for catching "wrong" urls that aren't extracted by `URLExtract.find_urls()` because they are not urls at all
-        An example: https://randomurl
+        Extracts anything that matches web URLs -- http, https, and naked domains like "example.com". Reference: https://gist.github.com/gruber/8891611
         Args:
-            text_with_urls (str, required): The text that contains the URLs where the check needs to be performed
-
+            text_with_urls (str, required): The text that contains the URLs
         Returns:
-            (list) List of texts that start with 'http' from `text_with_urls`
+            (set) Set of unique urls from `text_with_urls`
+        Examples:
+            >>> text = "Check out this website: https://example.com"
+            >>> _extract_urls_from_texts(text)
+            ['https://example.com']
         """
-        texts = text_with_urls.split(" ")
-        starts_with_http = set()
-        for text in texts:
-            if text.startswith("http"):
-                starts_with_http.add(text)
-        return starts_with_http
+        regex_pattern = r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b/?(?!@)))"""
+        return set(re.findall(regex_pattern, text_with_urls))
 
     @staticmethod
     @if_arg
@@ -53,14 +49,8 @@ class UrlValidator(StringValidator):
 
         validity = True
 
-        # extract URLs from text
-        extractor = URLExtract()
-        urls = extractor.find_urls(text_with_urls)
-        urls.extend(UrlValidator._extract_http_texts(text_with_urls))
+        urls = UrlValidator._extract_urls_from_texts(text_with_urls)
 
-        # remove dots at the end (The URLExtract library catches URLs, but sometimes appends a '.' at the end)
-        # remove duplicated urls
-        urls = set(url[:-1] if url.endswith(".") else url for url in urls)
         value = ", ".join(urls)
 
         # check that URL returns a valid response

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ requests==2.24.0
 setuptools==60.8.2
 strict-rfc3339==0.7
 tqdm==4.48.2
-urlextract==1.0.0
+urlextract==1.3.0
 xmltodict==0.12.0


### PR DESCRIPTION
### Description:
This pull request addresses the discrepancy in URL recommendations between pyQuARC and QuARC. 
### Issue: 
We are running pyQuARC in AWS Lambda functions to build the QuARC API. Lambda only supports a read-only file system. If someone attempts to write something to the Lambda, it throws an error. In our case, pyQuARC uses the `urlextract` package, which attempts to save some files in local storage for caching purposes, resulting in the error. The following is an extract from the class implemented in the pyQuARC.
` Initialize function for URLExtract class. Tries to get cached TLDs, if the cached file does not exist it will try to download the new list from IANA and save it to cache file.`
### Process: 
To resolve this, the dependency on the `urlextract` package has been replaced with regex expressions for URL extraction, eliminating the file system dependency.

### Testing : 
Testing was done with the following [list](https://docs.google.com/spreadsheets/d/1A1ivCqU0KPMv3RZ20pDW7Aga27JSZ4j9yCAP7KMA4sY/edit#gid=0) of concept ids with their respective formats ensuring we extract same list of URLs from a text using the regex expressions and `urlextract` package.

For further details :
https://github.com/NASA-IMPACT/pyQuARC/issues/273