### PR TITLE
Worked on ISO datetime format

### DIFF
--- a/pyQuARC/code/datetime_validator.py
+++ b/pyQuARC/code/datetime_validator.py
@@ -28,6 +28,9 @@ class DatetimeValidator(BaseValidator):
         """
         REGEX = r"^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$"
         match_iso8601 = re.compile(REGEX).match
+        parts = datetime_string.split('.')
+        if len(parts) == 2:
+            datetime_string = parts[0]
         try:
             if match_iso8601(datetime_string):
                 if datetime_string.endswith("Z"):

--- a/pyQuARC/code/datetime_validator.py
+++ b/pyQuARC/code/datetime_validator.py
@@ -28,9 +28,7 @@ class DatetimeValidator(BaseValidator):
         """
         REGEX = r"^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$"
         match_iso8601 = re.compile(REGEX).match
-        parts = datetime_string.split('.')
-        if len(parts) == 2:
-            datetime_string = parts[0]
+        datetime_string = datetime_string.split('.')[0]
         try:
             if match_iso8601(datetime_string):
                 if datetime_string.endswith("Z"):


### PR DESCRIPTION
This is a pull request to solve [this](https://github.com/NASA-IMPACT/pyQuARC/issues/266) issue. 

Overview:
In the pyQuarc, while running the collection, it showed the warning message like this:
<img width="902" alt="Screenshot 2024-04-11 at 10 26 03 AM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/7e0d3b5b-b09f-429b-831d-8ad868d6dd19">

Changes made:
Modified the code to solve the showing error that they are not provided in ISO format. Now, no warning shows up like the above. Tested on this 'G184443593-LARC' (echo-g)  and 'C179031451-LARC' (echo-c)collection to make sure the if the warning shows up.