### PR TITLE
DOI Link Update Check

### DIFF
--- a/pyQuARC/code/url_validator.py
+++ b/pyQuARC/code/url_validator.py
@@ -115,4 +115,4 @@ class UrlValidator(StringValidator):
         if value in bad_urls:
             validity = False
 
-        return {"valid": validity, "Value": value}
+        return {"valid": validity, "value": value}

--- a/pyQuARC/main.py
+++ b/pyQuARC/main.py
@@ -188,8 +188,6 @@ class ARC:
 
     @staticmethod
     def _error_message(messages):
-        if messages is None:
-            return ""
         severities = ["error", "warning", "info"]
         result_string = ""
         for message in messages:

--- a/pyQuARC/main.py
+++ b/pyQuARC/main.py
@@ -188,6 +188,8 @@ class ARC:
 
     @staticmethod
     def _error_message(messages):
+        if messages is None:
+            return ""
         severities = ["error", "warning", "info"]
         result_string = ""
         for message in messages:


### PR DESCRIPTION
This is the pull request to solve [this](https://github.com/NASA-IMPACT/pyQuARC/issues/263) issue.

Overview:
In the pyQuarc, while running the collection, it showed the error like this:
<img width="592" alt="Screenshot 2024-05-06 at 9 37 21 PM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/16942200-6fbc-4ae5-88c9-0559bb388d20">

Changes made:
Added an if condition to the `_error_message` function.
Now, above error is not shown.
Tested on echo-c record (C1411142649-LARC) to make sure if it stops quitting the pyQuARC.

<img width="1695" alt="Screenshot 2024-05-06 at 9 42 26 PM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/8eafdfff-1a7d-46b1-a92c-770683cc7f18">
