### PR TITLE
Use Constraints check errors.

### DIFF
--- a/pyQuARC/code/custom_checker.py
+++ b/pyQuARC/code/custom_checker.py
@@ -45,7 +45,11 @@ class CustomChecker:
             or isinstance(root_content, int)
             or isinstance(root_content, float)
         ):
-            container.append(root_content)
+            # if there is at least one element in new_path, the value can not be found
+            if new_path:
+                container.append(None)
+            else:
+                container.append(root_content)
             return
         elif isinstance(root_content, list):
             if not new_path:


### PR DESCRIPTION
This is the pull request to solve this [issue](https://github.com/NASA-IMPACT/pyQuARC/issues/264).

Overview:
In the pyQuarc, while running this collection (C2098742955-LARC (dif10)), it does not show the Use_Constraints errors.  

Changes made:
Added if conditions in _get_path_value_recursively function in custom_checker.py file. 
Now, Use_Constraints errors are shown for the collection C2098742955-LARC (dif10). 

<img width="576" alt="Screenshot 2024-06-26 at 8 02 59 AM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/6aa1239d-b639-41a1-b986-b0ea82ff5b43">

<img width="1687" alt="Screenshot 2024-06-26 at 8 04 03 AM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/b3709dc2-54f2-42d1-a77f-5c1a601b51a2">

<img width="966" alt="Screenshot 2024-06-26 at 8 04 33 AM" src="https://github.com/NASA-IMPACT/pyQuARC/assets/58721039/4f683ba3-fc46-479f-ac4b-8c9acee1d949">

