### PR TITLE
Collection date times not matching with granules errors

### DIFF
--- a/pyQuARC/code/constants.py
+++ b/pyQuARC/code/constants.py
@@ -79,10 +79,10 @@ GCMD_LINKS = {
 CMR_URL = "https://cmr.earthdata.nasa.gov"
 
 DATE_FORMATS = [
-    "%Y-%m-%dT%H:%M:%S.%f",  # Year to microsecond
-    "%Y-%m-%dT%H:%M:%S",  # Year to second
-    "%Y-%m-%dT%H:%M",  # Year to minute
-    "%Y-%m-%dT%H",  # Year to hour
+    "%Y-%m-%dT%H:%M:%S.%fZ",  # Year to microsecond
+    "%Y-%m-%dT%H:%M:%SZ",  # Year to second
+    "%Y-%m-%dT%H:%MZ",  # Year to minute
+    "%Y-%m-%dT%HZ",  # Year to hour
     "%Y-%m-%d",  # Year to day
     "%Y-%m",  # Year to month
     "%Y",  # Year


### PR DESCRIPTION
This is a pull request to solve [this](https://github.com/NASA-IMPACT/pyQuARC/issues/296) issue.

**Overview:**
At the collection level, pyQuARC was not flagging temporal extents that did not match with the granules.

**Example**
UMM-C Record: C2066317191-LARC

**Changes made:**
Added "Z" at the end of date_formates which follows standard ISO 8601 formatting rules with the 'Z' indicating UTC time.

Expected behavior:
pyQuARC is showing the error for the Beginning and Ending Date Times if it does not match with granules.

<img width="1337" alt="Screenshot 2024-10-02 at 11 30 06 AM" src="https://github.com/user-attachments/assets/6c263b90-ed6e-44e6-aecb-1ff9b6700855">
