### PR TITLE
Fix bug of Additional OnlineAccess and OnlineResource.

### DIFF
--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -4161,7 +4161,7 @@
             ]
         },
         "severity": "warning",
-        "check_id": "availability_check"
+        "check_id": "one_item_presence_check"
     },
     "characteristic_name_uniqueness_check": {
         "rule_name": "Characteristic Name Uniqueness Check",
@@ -4796,7 +4796,7 @@
             ]
         },
         "severity": "warning",
-        "check_id": "availability_check"
+        "check_id": "one_item_presence_check"
     },
     "get_data_url_check": {
         "rule_name": "GET DATA URL check",


### PR DESCRIPTION
This is a pull request to solve [this](https://github.com/NASA-IMPACT/pyQuARC/issues/298) issue.

**Description of the bug:**
pyQuARC does not flag the OnlineResource/Description, OnlineResource/Type, or OnlineAccess/Description fields whenever a URL is not provided. When ARC makes their recommendations, we also make recommendations for the fields above, even if a URL is not initially provided. The issue seems to be noticed with ECHO-C collections.

**Findings:**
While working with the fields OnlineResource/Description, OnlineResource/Type, or OnlineAccess/Description, we were using the checks `url_desc_presence_check` and `online_resource_type_presence_check`. These checks are linked to a check_id called `availability_check`, which is designed to accept two arguments: field_value and parent_value.

However, when I debugged the code, I noticed that our function is actually receiving only one argument, field_value. The function `one_item_presence_check` correctly uses just this single argument. To resolve this mismatch, I updated the rule mapping by changing the check_id from availability_check to one_item_presence_check.

**To Reproduce**
Example concept ID: C1627523804-LARC (echo-c)

Now, the above fields errors are seen.
<img width="1678" alt="Screenshot 2024-10-13 at 8 52 11 PM" src="https://github.com/user-attachments/assets/aff5afc0-f4fd-45db-bb2f-39867225236a">
