### PR TITLE
Add new check for OPeNDAP for for granules

### DIFF
--- a/pyQuARC/code/custom_validator.py
+++ b/pyQuARC/code/custom_validator.py
@@ -277,3 +277,53 @@ class CustomValidator(BaseValidator):
             items = [items]
         num_items = len(items)
         return {"valid": int(count) == num_items, "value": (count, num_items)}
+
+    @staticmethod
+    def opendap_link_check(related_urls, key, extra=None):
+        """
+        Checks if the related_urls contains an OPeNDAP link with the type "OPENDAP DATA" or URL containing "opendap".
+
+        Args:
+            related_urls (list): The related_urls field of the object, expected to be a list of URL objects.
+            key (dict): A dictionary with "type" and "url_keyword" keys for the checks.
+            extra (optional): An additional argument to match the expected function call signature. This argument is ignored.
+
+        Returns:
+            dict: A validation result indicating whether a valid OPeNDAP link is present and the link itself if found.
+        """
+
+        # If related_urls is None or not provided, initialize it as an empty list
+        if not related_urls:
+            related_urls = []
+
+        # If related_urls is not a list, assume it's a single URL string and wrap it in a list of one dictionary
+        elif isinstance(related_urls, str):
+            related_urls = [{"URL": related_urls, "Type": key.get("type", "OPENDAP DATA")}]
+
+        # Default return object if no valid OPeNDAP link is found
+        return_obj = {
+            "valid": False,
+            "value": "None"
+        }
+
+        # Extract type and keyword from key for clearer conditions
+        type_to_check = key.get("type", "OPENDAP DATA").upper()
+        url_keyword = key.get("url_keyword", "opendap").lower()
+
+        # Process each URL object in the list
+        for url_obj in related_urls:
+            # Ensure that url_obj is a dictionary before accessing its fields
+            if not isinstance(url_obj, dict):
+                continue
+
+            # Check for "opendap" in the URL
+            url_value = url_obj.get("URL", "").lower()
+            type_field = url_obj.get("Type", "").upper()
+
+            # Check if the URL contains "opendap" or if the Type matches "OPENDAP DATA"
+            if url_keyword in url_value or type_field == type_to_check:
+                return_obj["valid"] = True
+                return_obj["value"] = url_obj.get("URL", "None")
+                break
+
+        return return_obj

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -1070,5 +1070,13 @@
             "url": "https://wiki.earthdata.nasa.gov/display/CMR/Spatial+Extent"
         },
         "remediation": "Recommend providing the horizontal pixel resolution, if applicable. If provided, this information will be indexed in the EDSC 'Horizontal Data Resolution' search facet which allows users to search by spatial resolution."
+    },
+    "opendap_link_check": {
+    "failure": "No OPeNDAP URL is provided in the granule fields. An OPeNDAP link is recommended for data access.",
+    "help": {
+        "message": "OPeNDAP links allow for direct data access through the OPeNDAP protocol.",
+        "url": "https://wiki.earthdata.nasa.gov/display/CMR/Related+URLs"
+    },
+    "remediation": "Recommend providing an OPeNDAP in the granule's Online Resources or Related URLs fields for enhanced data accessibility."
     }
 }

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -298,5 +298,10 @@
         "data_type": "custom",
         "check_function": "count_check",
         "available": true
+    },
+    "opendap_link_check": {
+    "data_type": "custom",
+    "check_function": "opendap_link_check",
+    "available": true
     }
 }

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -3745,6 +3745,34 @@
         "severity": "error",
         "check_id": "string_compare"
     },
+    "opendap_link_check": {
+        "rule_name": "OPeNDAP Link Presence Check",
+        "fields_to_apply": {
+            "echo-g": [
+                {
+                    "fields": [
+                        "Granule/OnlineResources/OnlineResource/URL"
+                    ]
+                }
+            ],
+            "umm-g": [
+                {
+                    "fields": [
+                        "RelatedURLs/URL"
+                    ]
+                }
+            ]
+        },
+        "data": [
+            {
+                "type": "OPENDAP DATA",
+                "url_keyword": "opendap"
+            }
+        ],
+        "relation": "contains",
+        "check_id": "opendap_link_check",
+        "severity": "warning"
+    },
     "location_keyword_presence_check": {
         "rule_name": "Location Keyword Presence Check",
         "fields_to_apply": {


### PR DESCRIPTION
**Overview**
This pull request introduces a new check to verify the presence of OPeNDAP links in granule URL fields. The goal is to ensure that OPeNDAP links are included in the URL fields of granule metadata, improving data accessibility.

**New Check Details**
Check: Verify if OPeNDAP links are present in specified URL fields.
Fields:
Granule/OnlineResources/OnlineResource/URL (echo-g)
RelatedURLs/URL (umm-g)

**Check Logic**
The check inspects the specified URL fields for the presence of "opendap" in the URL.
If "opendap" is not found, a warning is generated, recommending the addition of an OPeNDAP link for this granule.

**Implementation Steps**
Added a new function, opendap_link_check, to perform the URL validation.
Added  rule_mapping.json to include this new check.
Added checks.json to enable the OPeNDAP link check.
Added check_message.json to define warning messages for missing OPeNDAP links.

**Testing**
Tested Granules:
echo-g: G1463204472-LAADS (Contains "opendap" in URL, with URL type "OPENDAP DATA") – No errors reported.
umm-g: G1997478801-LARC_ASDC (Does not contain "opendap" in URL or have URL type "OPENDAP DATA") – Error: Warning generated to recommend adding an OPeNDAP link.
 
<img width="1397" alt="Screenshot 2024-11-04 at 3 38 50 PM" src="https://github.com/user-attachments/assets/0f210f2a-bdbc-4f34-835e-0901c40ecfa2">

 