### PR TITLE
Added CMR Validation 

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest==6.2.5
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/pyQuARC/code/constants.py
+++ b/pyQuARC/code/constants.py
@@ -87,3 +87,9 @@ DATE_FORMATS = [
     "%Y-%m",  # Year to month
     "%Y",  # Year
 ]
+
+MAPPING_CMR = {
+    "umm-c": "vnd.nasa.cmr.umm+json",
+    "echo-c": "echo10+xml",
+    "dif10": "dif10+xml"
+}

--- a/pyQuARC/code/constants.py
+++ b/pyQuARC/code/constants.py
@@ -73,7 +73,8 @@ COLOR = {
 GCMD_BASIC_URL = "https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/"
 
 GCMD_LINKS = {
-    keyword: f"{GCMD_BASIC_URL}{keyword}?format=csv" for keyword in GCMD_KEYWORDS
+    keyword: f"{GCMD_BASIC_URL}{keyword}?format=csv"
+    for keyword in GCMD_KEYWORDS
 }
 
 CMR_URL = "https://cmr.earthdata.nasa.gov"
@@ -88,8 +89,10 @@ DATE_FORMATS = [
     "%Y",  # Year
 ]
 
-MAPPING_CMR = {
-    "umm-c": "vnd.nasa.cmr.umm+json",
-    "echo-c": "echo10+xml",
-    "dif10": "dif10+xml"
+CONTENT_TYPE_MAP = {
+    UMM_C: "vnd.nasa.cmr.umm+json",
+    UMM_G: "vnd.nasa.cmr.umm+json",
+    ECHO10_C: "echo10+xml",
+    ECHO10_G: "echo10+xml",
+    DIF: "dif10+xml"
 }

--- a/pyQuARC/code/schema_validator.py
+++ b/pyQuARC/code/schema_validator.py
@@ -3,7 +3,7 @@ import os
 import re
 
 from io import BytesIO
-from jsonschema import Draft7Validator, draft7_format_checker, RefResolver
+from jsonschema import Draft7Validator, RefResolver
 from lxml import etree
 from urllib.request import pathname2url
 
@@ -91,7 +91,7 @@ class SchemaValidator:
         resolver = RefResolver.from_schema(schema, store=schema_store)
 
         validator = Draft7Validator(
-            schema, format_checker=draft7_format_checker, resolver=resolver
+            schema, format_checker=Draft7Validator.FORMAT_CHECKER, resolver=resolver
         )
 
         for error in sorted(

--- a/pyQuARC/code/utils.py
+++ b/pyQuARC/code/utils.py
@@ -82,3 +82,11 @@ def get_date_time(dt_str):
         except ValueError:
             continue
     return None
+
+
+def get_concept_type(concept_id):
+    """
+    Extract the concept type from a given concept ID.
+    This is useful for determining the type of concept (e.g., 'collection', 'granule') from its ID.
+    """
+    return concept_id.startswith("C") and "collection" or "granule"

--- a/pyQuARC/main.py
+++ b/pyQuARC/main.py
@@ -243,10 +243,12 @@ class ARC:
         error_msg = ""
         if errors := cmr_validation.get("errors"):
             for error in errors:
-                print(error)
-                if error["path"][0] not in error_msg_dict:
-                    error_msg_dict[error["path"][0]] = []
-                error_msg_dict[error["path"][0]].append(error['errors'])
+                if type(error) is dict and error.get("path"):
+                    if error["path"][0] not in error_msg_dict:
+                        error_msg_dict[error["path"][0]] = []
+                    error_msg_dict[error["path"][0]].append(error['errors'])
+                else:
+                    error_msg_dict["Misc"] = [error]
         for path, errors in error_msg_dict.items():
             error_msg += f"\n\t>> {path}: {END}\n"
             for error in errors:
@@ -285,7 +287,7 @@ class ARC:
                     f"\n\t {COLOR['title']}{COLOR['bright']} pyQuARC ERRORS: {END}\n"
                 )
                 for error in pyquarc_errors:
-                    error_prompt += f"\t\t  ERROR: {error['message']}. Details: {error['details']} \n"
+                    error_prompt += f"\t\t  ERROR: {error['type']}. Details: {error['details']} \n"
 
             if cmr_validation := error.get("cmr_validation"):
                 cmr_error_msg = self._format_cmr_error(cmr_validation)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,11 +9,11 @@ class TestDownloader:
     def setup_method(self):
         self.concept_ids = {
             "collection": {
-                "real": "C1339230297-GES_DISC",
+                "real": "C2515837343-GES_DISC",
                 "dummy": "C123456-LPDAAC_ECS",
             },
             "granule": {
-                "real": "G1370895082-GES_DISC",
+                "real": "G2519682101-GES_DISC",
                 "dummy": "G1000000002-CMR_PROV",
             },
             "invalid": "asdfasdf",


### PR DESCRIPTION
This is a PR to solve [this](https://github.com/NASA-IMPACT/pyQuARC/issues/269) issue.

**Description:**
The CMR Team recommended that pyQuARC use the CMR API for basic validation checks (metadata schema, controlled vocabulary) rather than having a separate validation. If CMR validation changes, they want to ensure that users are not using outdated validation in pyQuARC. They also want to verify consistency between what results are provided to users in pyQuARC and CMR.

**Steps Implemented**
1. `_validate_with_cmr` function: Validates the collection using the [CMR API](https://cmr.earthdata.nasa.gov/ingest/site/docs/ingest/api.html#collection).
2. `add_cmr_response` function: Categorizes API responses as warnings or errors.
3. Integrated these functions into main.py:

-  Validates collections via the API.
- Appends API response errors as cmr_errors and warnings as cmr_warnings in the output of the error.