### PR TITLE
OnlineAccessUrls and OnlineResource (echo-g)

### DIFF
--- a/pyQuARC/code/schema_validator.py
+++ b/pyQuARC/code/schema_validator.py
@@ -3,7 +3,7 @@ import os
 import re
 
 from io import BytesIO
-from jsonschema import Draft7Validator, draft7_format_checker, RefResolver
+from jsonschema import Draft7Validator, RefResolver 
 from lxml import etree
 from urllib.request import pathname2url
 
@@ -90,9 +90,7 @@ class SchemaValidator:
 
         resolver = RefResolver.from_schema(schema, store=schema_store)
 
-        validator = Draft7Validator(
-            schema, format_checker=draft7_format_checker, resolver=resolver
-        )
+        validator = Draft7Validator(schema, format_checker=Draft7Validator.FORMAT_CHECKER)
 
         for error in sorted(
             validator.iter_errors(json.loads(content_to_validate)), key=str
@@ -136,13 +134,13 @@ class SchemaValidator:
             # For DIF, because the namespace is specified in the metadata file, lxml library
             # provides field name concatenated with the namespace,
             # the following 3 lines of code removes the namespace
-            namespaces = re.findall("(\{http[^}]*\})", line)
+            namespaces = re.findall(r"(\{http[^}]*\})", line)
             for namespace in namespaces:
                 line = line.replace(namespace, "")
-            field_name = re.search("Element\s'(.*)':", line)[1]
+            field_name = re.search(r"Element\s'(.*)':", line)[1]
             field_paths = [abs_path for abs_path in paths if field_name in abs_path]
             field_name = field_paths[0] if len(field_paths) == 1 else field_name
-            message = re.search("Element\s'.+':\s(\[.*\])?(.*)", line)[2].strip()
+            message = re.search(r"Element\s'.+':\s(\[.*\])?(.*)", line)[2].strip()
             errors.setdefault(field_name, {})["schema"] = {
                 "message": [f"Error: {message}"],
                 "valid": False,

--- a/pyQuARC/code/url_validator.py
+++ b/pyQuARC/code/url_validator.py
@@ -66,34 +66,126 @@ class UrlValidator(StringValidator):
 
         # check that URL returns a valid response
         for url in urls:
-            if not url.startswith("http"):
-                url = f"http://{url}"
-            try:
-                response_code = status_code_from_request(url)
-                if response_code == 200:
-                    if url.startswith("http://"):
-                        secure_url = url.replace("http://", "https://")
-                        if status_code_from_request(secure_url) == 200:
-                            result = {
-                                "url": url,
-                                "error": "The URL is secure. Please use 'https' instead of 'http'.",
-                            }
+            if url.startswith("http"):
+                try:
+                    response_code = status_code_from_request(url)  
+                    if response_code == 200:
+                        if url.startswith("http://"):
+                            secure_url = url.replace("http://", "https://")
+                            if status_code_from_request(secure_url) == 200:
+                                result = {
+                                    "url": url,
+                                    "error": f"The {url} is secure. Please use 'https' instead of 'http'.",
+                                }     
+                        else:
+                            continue
                     else:
-                        continue
-                else:
-                    result = {"url": url, "error": f"Status code {response_code}"}
-            except requests.ConnectionError:
-                result = {"url": url, "error": "The URL does not exist on Internet."}
-            except:
-                result = {"url": url, "error": "Some unknown error occurred."}
-            results.append(result)
-
+                        result = {"url": url, "error": f"Status code {response_code}"}
+                except requests.ConnectionError:
+                    result = {"url": url, "error": f"The URL {url} does not exist on Internet."}
+                except:
+                    result = {"url": url, "error": "Some unknown error occurred."}
+                results.append(result)
+            
         if results:
             validity = False
             value = results
+        
+        return {"valid": validity, "value":  value}
 
-        return {"valid": validity, "value": value}
+    @staticmethod
+    @if_arg
+    def protocol_checks(text_with_urls):
+        """
+        Checks the ftp included in `text_with_urls`
+        Args:
+           text_with_urls (str, required): The text that contains ftp
+        Returns:
+            (dict) An object with the validity of the check and the instance/results
+        """
 
+        results = []
+
+        validity = True
+
+        # extract URLs from text
+        extractor = URLExtract(cache_dir=os.environ.get("CACHE_DIR"))
+        urls = extractor.find_urls(text_with_urls)
+        urls.extend(UrlValidator._extract_http_texts(text_with_urls))
+
+        # remove dots at the end (The URLExtract library catches URLs, but sometimes appends a '.' at the end)
+        # remove duplicated urls
+        urls = set(url[:-1] if url.endswith(".") else url for url in urls)
+        value = ", ".join(urls)
+
+        # check that URL is ftp or http
+        for url in urls:
+            if url.startswith("ftp://"):
+                results.append({
+                "url": url, 
+                "error": f"The URL {url} exists"
+                })
+           
+        if results:
+            validity = False
+            value = results
+        
+        return {"valid": validity, "value":  value}
+
+    @staticmethod
+    @if_arg
+    def secure_url_checks(text_with_urls):
+        """
+        Checks the ftp included in `text_with_urls`
+        Args:
+           text_with_urls (str, required): The text that contains ftp
+        Returns:
+            (dict) An object with the validity of the check and the instance/results
+        """
+
+        results = []
+
+        validity = True
+
+        # extract URLs from text
+        extractor = URLExtract(cache_dir=os.environ.get("CACHE_DIR"))
+        urls = extractor.find_urls(text_with_urls)
+        urls.extend(UrlValidator._extract_http_texts(text_with_urls))
+
+        # remove dots at the end (The URLExtract library catches URLs, but sometimes appends a '.' at the end)
+        # remove duplicated urls
+        urls = set(url[:-1] if url.endswith(".") else url for url in urls)
+        value = ", ".join(urls)
+
+        # check that URL is ftp or http
+        for url in urls:
+            if url.startswith("http://"):
+                results.append({
+                "url": url, 
+                "error": f"The URL {url} is not secure"
+                })
+           
+        if results:
+            validity = False
+            value = results
+        
+        return {"valid": validity, "value":  value}
+
+    @staticmethod
+    @if_arg
+    def doi_check(doi):
+        """
+        Checks if the doi link given in the text is a valid doi link
+
+        Returns:
+            (dict) An object with the validity of the check and the instance/results
+        """
+        valid = False
+        if doi.strip().startswith("10."):  # doi always starts with "10."
+            url = f"https://www.doi.org/{doi}"
+            valid = UrlValidator.health_and_status_check(url).get("valid")
+        return {"valid": valid, "value": doi}
+    
     @staticmethod
     @if_arg
     def doi_check(doi):

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -40,12 +40,28 @@
         "remediation": "Recommend updating the Revision date so that it comes chronologically after the Insert/Creation time."
     },
     "url_check": {
-        "failure": "A URL with a status code other than 200 has been identified: `{}`.",
+        "failure": "`{}`.",
         "help": {
             "message": "",
             "url": "https://en.wikipedia.org/wiki/List_of_HTTP_status_codes"
         },
-        "remediation": "This often indicates a broken link. If the URL is broken, recommend revising."
+        "remediation": "Recommend updating broken HTTP/HTTPS links."
+    },
+    "protocol_check": {
+        "failure": "`{}`.",
+        "help": {
+            "message": "",
+            "url": "https://en.wikipedia.org/wiki/List_of_HTTP_status_codes"
+        },
+        "remediation": "Recommend removing FTP links."
+    },
+    "secure_url_check": {
+        "failure": "`{}`.",
+        "help": {
+            "message": "",
+            "url": "https://en.wikipedia.org/wiki/List_of_HTTP_status_codes"
+        },
+        "remediation": "Recommend updating the following link(s) from 'http' to 'https':"
     },
     "shortname_uniqueness": {
         "failure": "The EntryTitle/DataSetId `{}` is identical to the ShortName `{}`.",
@@ -821,7 +837,7 @@
             "message": "",
             "url": ""
         },
-        "remediation": "Recommend updating to 'HTTPS'."
+        "remediation": "Recommend removing the ftp access link: ftp://gdc.cddis.eosdis.nasa.gov/....."
     },
     "citation_version_check": {
         "failure": "The version listed in the citation `{}` does not match the version of the collection `{}`.",
@@ -845,7 +861,7 @@
             "message": "",
             "url": "https://wiki.earthdata.nasa.gov/display/CMR/Related+URLs"
         },
-        "remediation": "Recommend providing a description for each URL that is provided."
+        "remediation": "Recommend providing a description for the Online Access URL."
     },
     "get_data_url_check": {
         "failure": "No 'GET DATA' link is provided.",

--- a/pyQuARC/schemas/checks.json
+++ b/pyQuARC/schemas/checks.json
@@ -24,6 +24,16 @@
         "check_function": "health_and_status_check",
         "available": true
     },
+    "protocol_check": {
+        "data_type": "url",
+        "check_function": "protocol_checks",
+        "available": true
+    },
+    "secure_url_check": {
+        "data_type": "url",
+        "check_function": "secure_url_checks",
+        "available": true
+    },
     "string_compare": {
         "data_type": "string",
         "check_function": "compare",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -812,6 +812,260 @@
         "severity": "error",
         "check_id": "url_check"
     },
+    "protocol_check": {
+        "rule_name": "protocol_checks",
+        "fields_to_apply": {
+            "echo-c": [
+                {
+                    "fields": [
+                        "Collection/Description"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/SuggestedUsage"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/CitationforExternalPublication"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/OnlineAccessURLs/OnlineAccessURL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/OnlineResources/OnlineResource/URL"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Extended_Metadata/Metadata/Value"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Dataset_Citation/Online_Resource"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Summary/Abstract"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Organization/Organization_URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Related_URL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Extended_Metadata/Metadata/Value"
+                    ]
+                }
+            ],
+            "umm-c": [
+                {
+                    "fields": [
+                        "DataCenters/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DataCenters/ContactPersons/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DataCenters/ContactGroups/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "ContactPersons/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "ContactGroups/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "RelatedUrls/URL"
+                    ]
+                }
+            ],
+            "umm-g": [
+                {
+                    "fields": [
+                        "RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "MetadataSpecification/URL"
+                    ]
+                }
+            ],
+            "echo-g": [
+                {
+                    "fields": [
+                        "Granule/OnlineAccessURLs/OnlineAccessURL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Granule/OnlineResources/OnlineResource/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Granule/AssociatedBrowseImageUrls/ProviderBrowseUrl/URL"
+                    ]
+                }
+            ]
+        },
+        "severity": "error",
+        "check_id": "protocol_check"
+    },
+    "secure_url_check": {
+        "rule_name": "secure_url_checks",
+        "fields_to_apply": {
+            "echo-c": [
+                {
+                    "fields": [
+                        "Collection/Description"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/SuggestedUsage"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/CitationforExternalPublication"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/OnlineAccessURLs/OnlineAccessURL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Collection/OnlineResources/OnlineResource/URL"
+                    ]
+                }
+            ],
+            "dif10": [
+                {
+                    "fields": [
+                        "DIF/Extended_Metadata/Metadata/Value"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Dataset_Citation/Online_Resource"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Summary/Abstract"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Organization/Organization_URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Related_URL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DIF/Extended_Metadata/Metadata/Value"
+                    ]
+                }
+            ],
+            "umm-c": [
+                {
+                    "fields": [
+                        "DataCenters/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DataCenters/ContactPersons/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "DataCenters/ContactGroups/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "ContactPersons/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "ContactGroups/ContactInformation/RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "RelatedUrls/URL"
+                    ]
+                }
+            ],
+            "umm-g": [
+                {
+                    "fields": [
+                        "RelatedUrls/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "MetadataSpecification/URL"
+                    ]
+                }
+            ],
+            "echo-g": [
+                {
+                    "fields": [
+                        "Granule/OnlineAccessURLs/OnlineAccessURL/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Granule/OnlineResources/OnlineResource/URL"
+                    ]
+                },
+                {
+                    "fields": [
+                        "Granule/AssociatedBrowseImageUrls/ProviderBrowseUrl/URL"
+                    ]
+                }
+            ]
+        },
+        "severity": "info",
+        "check_id": "secure_url_check"
+    },
     "shortname_uniqueness": {
         "rule_name": "Short Name uniqueness check",
         "fields_to_apply": {

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,11 +9,11 @@ class TestDownloader:
     def setup_method(self):
         self.concept_ids = {
             "collection": {
-                "real": "C1339230297-GES_DISC",
+                "real": "C1000000010-CDDIS",
                 "dummy": "C123456-LPDAAC_ECS",
             },
             "granule": {
-                "real": "G1370895082-GES_DISC",
+                "real": "G1001434969-CDDIS",
                 "dummy": "G1000000002-CMR_PROV",
             },
             "invalid": "asdfasdf",


### PR DESCRIPTION
This is a pull request for issue url_description_uniqueness_check (Granule): https://github.com/NASA-IMPACT/pyQuARC/issues/322

Expected outcome:
For OnlineAccessURLs / OnlineAccessURL / URL PyQuARC should flag:
if there is ftp link in urls (Error)
if the url is broken (Error) and
if the http link is not secure (Info)

Code Changes:
Added a new check function for protocol check and secure http link in the url_validator.py and added corresponding check messages and registered new checks in check_messages.json and checks.json respectively.
Finally, added the corresponding rule mappings in rule_mapping.json.

To Reproduce:
Example concept ID: G2488091813-CDDIS --format echo-g

Problem:
While checking the broken link most of the urls returned 200 status code while visiting the url instead of downloading the data. So it was not possible to check the broken link with any granule id. To simulate a broken link scenario, temporarily hardcode a 404 response code in the health_and_status_check function in url_validator.py in line 71.