### PR TITLE
CollectionProgress and temporalExtent flag - Inconsistency

### DIFF
--- a/pyQuARC/code/schema_validator.py
+++ b/pyQuARC/code/schema_validator.py
@@ -3,7 +3,7 @@ import os
 import re
 
 from io import BytesIO
-from jsonschema import Draft7Validator, draft7_format_checker, RefResolver
+from jsonschema import Draft7Validator, RefResolver 
 from lxml import etree
 from urllib.request import pathname2url
 
@@ -90,9 +90,7 @@ class SchemaValidator:
 
         resolver = RefResolver.from_schema(schema, store=schema_store)
 
-        validator = Draft7Validator(
-            schema, format_checker=draft7_format_checker, resolver=resolver
-        )
+        validator = Draft7Validator(schema, format_checker=Draft7Validator.FORMAT_CHECKER)
 
         for error in sorted(
             validator.iter_errors(json.loads(content_to_validate)), key=str
@@ -136,13 +134,13 @@ class SchemaValidator:
             # For DIF, because the namespace is specified in the metadata file, lxml library
             # provides field name concatenated with the namespace,
             # the following 3 lines of code removes the namespace
-            namespaces = re.findall("(\{http[^}]*\})", line)
+            namespaces = re.findall(r"(\{http[^}]*\})", line)
             for namespace in namespaces:
                 line = line.replace(namespace, "")
-            field_name = re.search("Element\s'(.*)':", line)[1]
+            field_name = re.search(r"Element\s'(.*)':", line)[1]
             field_paths = [abs_path for abs_path in paths if field_name in abs_path]
             field_name = field_paths[0] if len(field_paths) == 1 else field_name
-            message = re.search("Element\s'.+':\s(\[.*\])?(.*)", line)[2].strip()
+            message = re.search(r"Element\s'.+':\s(\[.*\])?(.*)", line)[2].strip()
             errors.setdefault(field_name, {})["schema"] = {
                 "message": [f"Error: {message}"],
                 "valid": False,

--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -205,7 +205,7 @@
             "message": "",
             "url": ""
         },
-        "remediation": "If data collection is ongoing, provide an EndsAtPresentFlag of \"true\""
+        "remediation": "Since data collection is no longer ongoing, recommend updating the EndsAtPresentFlag to 'false'."
     },
     "ends_at_present_flag_presence_check": {
         "failure": "Potential issue with:\n - No EndingDateTime provided; no EndsAtPresentFlag provided for a potentially active collection. \n - CollectionState is not \"COMPLETE\"; no EndsAtPresentFlag provided for a potentially active collection.",
@@ -736,12 +736,12 @@
         "remediation": "Recommend providing an entry of 'true' or 'false'."
     },
     "collection_progress_consistency_check": {
-        "failure": "The Collection State/Progress `{}` is not consistent with the Ending Date Time and/or the Ends At Present Flag.",
+        "failure": "The Collection Progress `{}` is not consistent with the Ending Date Time and/or the Ends At Present Flag.",
         "help": {
             "message": "",
             "url": "https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress"
         },
-        "remediation": "Recommend updating the Collection State/Progress based on the Ending Date Time and Ends At Present Flag values."
+        "remediation": "Recommend updating the Collection Progress based on the Ending Date Time and Ends At Present Flag values."
     },
     "online_resource_type_gcmd_check": {
         "failure": "The provided Online Resource/Related URLs Type `{}` is not consistent with GCMD.",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -1315,7 +1315,7 @@
                 }
             ]
         },
-        "severity": "warning",
+        "severity": "error",
         "check_id": "ends_at_present_flag_logic_check"
     },
     "ends_at_present_flag_presence_check": {

--- a/tests/fixtures/test_cmr_metadata.umm-c
+++ b/tests/fixtures/test_cmr_metadata.umm-c
@@ -335,7 +335,8 @@
             "PrecisionOfSeconds": 4,
             "RangeDateTimes": [
                 {
-                    "BeginningDateTime": "2000-02-18T00:00:00.000Z"
+                    "BeginningDateTime": "2000-02-18T00:00:00.000Z",
+                    "EndingDateTime": "2003-02-18T00:00:00.000Z"
                 }
             ]
         }

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,11 +9,11 @@ class TestDownloader:
     def setup_method(self):
         self.concept_ids = {
             "collection": {
-                "real": "C1339230297-GES_DISC",
+                "real": "C1000000010-CDDIS",
                 "dummy": "C123456-LPDAAC_ECS",
             },
             "granule": {
-                "real": "G1370895082-GES_DISC",
+                "real": "G1001434969-CDDIS",
                 "dummy": "G1000000002-CMR_PROV",
             },
             "invalid": "asdfasdf",


### PR DESCRIPTION
This is a pull request for issue https://github.com/NASA-IMPACT/pyQuARC/issues/348. 

Expected outcome:
PyQuARC should flag records with EndingDateTime present (when there is a value in the TemporalExtent/EndingDatetime, then EndsAtPresentFlag should be "false" and CollectionProgress should be "COMPLETE"
Recommendation for EndsAtPresentFlag:
"Since data collection is no longer ongoing, recommend updating the EndsAtPresentFlag to 'false'."
Recommendation for CollectionProgress:
"Data collection appears to be complete. Recommend changing the Collection Progress to 'COMPLETE'."

Code Changes:
Made updates in check_messages.json and changed the severity from warning to error in rule_mapping.json.

To Reproduce:
Add "EndingDateTime" in the TemporalExtent range date times and run test_cmr_metadata.umm-c.