### PR TITLE
Granule datetime 'Z' missing

### DIFF
--- a/pyQuARC/code/datetime_validator.py
+++ b/pyQuARC/code/datetime_validator.py
@@ -87,9 +87,17 @@ class DatetimeValidator(BaseValidator):
         Returns:
             (dict) An object with the validity of the check and the instance
         """
+        is_datetime = DatetimeValidator._iso_datetime(datetime_string)
+        is_date = DatetimeValidator._iso_date(datetime_string)
+
+        # If it's a datetime, require that it ends with 'Z'
+        if is_datetime and not datetime_string.endswith("Z"):
+            is_datetime = False
+
+        valid = is_datetime or is_date
+
         return {
-            "valid": bool(DatetimeValidator._iso_datetime(datetime_string))
-            or bool(DatetimeValidator._iso_date(datetime_string)),
+            "valid": valid,
             "value": datetime_string,
         }
 


### PR DESCRIPTION
**Description of the bug and fix:** In the granules, we encountered a datetime format string that did not adhere to the ISO 8601 standard with the 'Z' appended to the end of the string. We follow the Coordinated Universal Time (UTC) by appending 'Z' to the end of the string to avoid ambiguity of different regional date and time formats. 
If the 'Z' is missing, we need to flag for error (RED). We check the format across different datetime strings. 

**Code changes**: The changes were made in the `datetime_validator.py` to include the 'Z' in the datetime format check. We ensured that the format was checked across various fields, including Granule//LastUpdate, InsertTime, Temporal/RangeDateTime/BeginningDateTime, Temporal/RangeDateTime/EndingDateTime, etc. 

**Example:** G1002396549-CDDIS (echo-g), Collection C1000000017-CDDIS

**Expected results:** 
See the screenshot
<img width="717" height="271" alt="Screenshot 2025-09-05 at 11 48 08 AM" src="https://github.com/user-attachments/assets/17284b68-863e-4245-8ef5-db69b1fe464f" />

