### PR TITLE
CollectionProgress and temporalExtent flag - Inconsistency

### DIFF
--- a/pyQuARC/schemas/check_messages.json
+++ b/pyQuARC/schemas/check_messages.json
@@ -205,7 +205,7 @@
             "message": "",
             "url": ""
         },
-        "remediation": "If data collection is ongoing, provide an EndsAtPresentFlag of \"true\""
+        "remediation": "Since data collection is no longer ongoing, recommend updating the EndsAtPresentFlag to 'false'."
     },
     "ends_at_present_flag_presence_check": {
         "failure": "Potential issue with:\n - No EndingDateTime provided; no EndsAtPresentFlag provided for a potentially active collection. \n - CollectionState is not \"COMPLETE\"; no EndsAtPresentFlag provided for a potentially active collection.",
@@ -736,12 +736,12 @@
         "remediation": "Recommend providing an entry of 'true' or 'false'."
     },
     "collection_progress_consistency_check": {
-        "failure": "The Collection State/Progress `{}` is not consistent with the Ending Date Time and/or the Ends At Present Flag.",
+        "failure": "The Collection Progress `{}` is not consistent with the Ending Date Time and/or the Ends At Present Flag.",
         "help": {
             "message": "",
             "url": "https://wiki.earthdata.nasa.gov/display/CMR/Collection+Progress"
         },
-        "remediation": "Recommend updating the Collection State/Progress based on the Ending Date Time and Ends At Present Flag values."
+        "remediation": "Recommend updating the Collection Progress based on the Ending Date Time and Ends At Present Flag values."
     },
     "online_resource_type_gcmd_check": {
         "failure": "The provided Online Resource/Related URLs Type `{}` is not consistent with GCMD.",

--- a/pyQuARC/schemas/rule_mapping.json
+++ b/pyQuARC/schemas/rule_mapping.json
@@ -1315,7 +1315,7 @@
                 }
             ]
         },
-        "severity": "warning",
+        "severity": "error",
         "check_id": "ends_at_present_flag_logic_check"
     },
     "ends_at_present_flag_presence_check": {


### PR DESCRIPTION
This is a pull request for issue https://github.com/NASA-IMPACT/pyQuARC/issues/348.

Expected outcome:
PyQuARC should flag records with EndingDateTime present (when there is a value in the TemporalExtent/EndingDatetime, then EndsAtPresentFlag should be "false" and CollectionProgress should be "COMPLETE"
Recommendation for EndsAtPresentFlag:
"Since data collection is no longer ongoing, recommend updating the EndsAtPresentFlag to 'false'."
Recommendation for CollectionProgress:
"Data collection appears to be complete. Recommend changing the Collection Progress to 'COMPLETE'."

Code Changes:
Made updates in check_messages.json and changed the severity from warning to error in rule_mapping.json.

To Reproduce:
Add "EndingDateTime" in the TemporalExtent range date times and set the  "EndsAtPresentFlag" false and run test_cmr_metadata.umm-c.

Expected outcome:
<img width="1299" height="607" alt="image" src="https://github.com/user-attachments/assets/295a7a5d-fead-429d-910b-6a2f47daeb7b" />
